### PR TITLE
Fix WebGPU recovery for compute, readback and generated data

### DIFF
--- a/examples/src/examples/compute/histogram.example.mjs
+++ b/examples/src/examples/compute/histogram.example.mjs
@@ -170,6 +170,16 @@ solid.setLocalScale(0.35, 0.35, 0.35);
 app.root.addChild(solid);
 
 let firstFrame = true;
+let readGeneration = 0;
+const onDeviceLost = device.on('devicelost', () => {
+    readGeneration++;
+    firstFrame = true;
+});
+app.on('destroy', () => {
+    readGeneration++;
+    onDeviceLost.off();
+});
+
 app.on('update', (/** @type {number} */ _dt) => {
     // The update function runs every frame before the frame gets rendered. On the first time it
     // runs, the scene color map has not been rendered yet, so we skip the first frame.
@@ -190,16 +200,28 @@ app.on('update', (/** @type {number} */ _dt) => {
         // will be resolved later, when the GPU is done running it, and so the histogram on the
         // screen will be up to few frames behind.
         const histogramData = new Uint32Array(numBins);
-        histogramStorageBuffer.read(0, undefined, histogramData).then((data) => {
-            // Render the histogram using lines
-            const scale = 1 / 50000;
-            const positions = [];
-            for (let x = 0; x < data.length; x++) {
-                const value = math.clamp(data[x] * scale, 0, 0.2);
-                positions.push(x * 0.001, -0.35, 4);
-                positions.push(x * 0.001, value - 0.35, 4);
-            }
-            app.drawLineArrays(positions, Color.YELLOW);
-        });
+        const generation = readGeneration;
+        histogramStorageBuffer
+            .read(0, undefined, histogramData)
+            .then((data) => {
+                // A request can settle after recovery or application destruction.
+                if (generation !== readGeneration) return;
+
+                // Render the histogram using lines
+                const scale = 1 / 50000;
+                const positions = [];
+                for (let x = 0; x < data.length; x++) {
+                    const value = math.clamp(data[x] * scale, 0, 0.2);
+                    positions.push(x * 0.001, -0.35, 4);
+                    positions.push(x * 0.001, value - 0.35, 4);
+                }
+                app.drawLineArrays(positions, Color.YELLOW);
+            })
+            .catch((error) => {
+                // Interrupted reads are replaced by fresh results on subsequent frames.
+                if (error.name !== 'AbortError' && generation === readGeneration && !device.isContextLost()) {
+                    throw error;
+                }
+            });
     }
 });

--- a/examples/src/examples/test/radix-sort-compute.example.mjs
+++ b/examples/src/examples/test/radix-sort-compute.example.mjs
@@ -161,6 +161,21 @@ let sortedIndicesBuffer = null;
 let originalValues = [];
 /** @type {boolean} */
 let needsRegen = true;
+let readGeneration = 0;
+
+const deviceLost = device.on('devicelost', () => {
+    readGeneration++;
+    pendingVerification = null;
+});
+const deviceRestored = device.on('devicerestored', () => {
+    // Storage buffers are recreated empty; preserve the same input for comparison.
+    keysBuffer?.write(0, new Uint32Array(originalValues));
+});
+app.on('destroy', () => {
+    readGeneration++;
+    deviceLost.off();
+    deviceRestored.off();
+});
 
 // Valid radix modes. After benchmarking across NVIDIA / Apple / Mali / IMG
 // The surviving variants are:
@@ -489,7 +504,14 @@ async function doVerification(sortedIndices, capturedOriginalValues, capturedNum
 
     // Read the sorted indices buffer
     const indicesData = new Uint32Array(capturedNumElements);
-    await sortedIndices.read(0, capturedNumElements * 4, indicesData, true);
+    const generation = readGeneration;
+    try {
+        await sortedIndices.read(0, capturedNumElements * 4, indicesData, true);
+    } catch (error) {
+        if (error.name === 'AbortError' || generation !== readGeneration) return;
+        throw error;
+    }
+    if (generation !== readGeneration) return;
 
     // Get sorted values by looking up original values
     const sortedValues = [];

--- a/examples/src/examples/test/radix-sort-indirect-compute.example.mjs
+++ b/examples/src/examples/test/radix-sort-indirect-compute.example.mjs
@@ -107,6 +107,20 @@ let originalValues = [];
 let needsRegen = true;
 /** @type {boolean} */
 let verificationPending = false;
+let readGeneration = 0;
+
+const deviceLost = device.on('devicelost', () => {
+    readGeneration++;
+});
+const deviceRestored = device.on('devicerestored', () => {
+    // Keep the CPU reference and the recreated GPU input buffer in agreement.
+    keysBuffer?.write(0, new Uint32Array(originalValues));
+});
+app.on('destroy', () => {
+    readGeneration++;
+    deviceLost.off();
+    deviceRestored.off();
+});
 
 let totalTests = 0;
 let totalPassed = 0;
@@ -260,7 +274,14 @@ async function doVerification(sortedIndices, capturedValues, maxElements, visibl
 
     // Read back sorted indices (only visibleCount entries matter)
     const indicesData = new Uint32Array(visibleCount);
-    await sortedIndices.read(0, visibleCount * 4, indicesData, true);
+    const generation = readGeneration;
+    try {
+        await sortedIndices.read(0, visibleCount * 4, indicesData, true);
+    } catch (error) {
+        if (error.name === 'AbortError' || generation !== readGeneration) return;
+        throw error;
+    }
+    if (generation !== readGeneration) return;
 
     // Check 1: All indices in range [0, visibleCount)
     let outOfRangeCount = 0;

--- a/examples/src/examples/test/scene-depth-read.example.mjs
+++ b/examples/src/examples/test/scene-depth-read.example.mjs
@@ -20,6 +20,7 @@ import {
     Color,
     Entity,
     FILLMODE_FILL_WINDOW,
+    GSplatComponentSystem,
     LightComponentSystem,
     PROJECTION_ORTHOGRAPHIC,
     RESOLUTION_AUTO,
@@ -39,7 +40,12 @@ const device = await createGraphicsDevice(canvas, { deviceTypes: [deviceType], a
 
 const createOptions = new AppOptions();
 createOptions.graphicsDevice = device;
-createOptions.componentSystems = [RenderComponentSystem, CameraComponentSystem, LightComponentSystem];
+createOptions.componentSystems = [
+    RenderComponentSystem,
+    CameraComponentSystem,
+    LightComponentSystem,
+    GSplatComponentSystem
+];
 
 const app = new AppBase(canvas);
 app.init(createOptions);

--- a/examples/src/examples/test/texture-copy.example.mjs
+++ b/examples/src/examples/test/texture-copy.example.mjs
@@ -229,6 +229,10 @@ const results = [];
  * @param {number} readH - Height to read back from dest.
  */
 const runRow = async (label, source, dest, options, expected, readW, readH) => {
+    // The copied pixels only exist on the GPU, so repeat the copy after restoration.
+    const restored = device.on('devicerestored', () => dest.copy(source, options));
+    app.on('destroy', () => restored.off());
+
     const ok = dest.copy(source, options);
     addImage(source, 0, rowY);
     addImage(dest, 1, rowY);

--- a/src/framework/graphics/picker.js
+++ b/src/framework/graphics/picker.js
@@ -249,9 +249,9 @@ class Picker {
             return this.decodePixels(pixels, this.mapping);
         }).catch((error) => {
             // a read which could not complete because the device has gone reports an empty selection,
-            // which is what decodePixels reports for the same reason. Every other failure is a real one
+            // including cancellation before the device loss notification arrives. Every other failure is a real one
             // and is passed on, rather than being disguised as nothing having been selected.
-            if (this.deviceValid) {
+            if (this.deviceValid && !this.device.isContextLost() && error.name !== 'AbortError') {
                 throw error;
             }
             return [];
@@ -355,9 +355,9 @@ class Picker {
         try {
             pixels = await this._readTexture(this.depthBuffer, x, y, 1, 1, this.renderTargetDepth);
         } catch (error) {
-            // as in getSelectionAsync - only a device which has gone reports as nothing picked, and
-            // every other failure is passed on
-            if (this.deviceValid) {
+            // Mapping can be cancelled before the device loss notification arrives. Other failures
+            // on a valid device must still be reported.
+            if (this.deviceValid && !this.device.isContextLost() && error.name !== 'AbortError') {
                 throw error;
             }
             return null;

--- a/src/platform/graphics/compute.js
+++ b/src/platform/graphics/compute.js
@@ -25,6 +25,9 @@ class ComputeParameter {
 /**
  * A representation of a compute shader with the associated resources, that can be executed on the
  * GPU. Only supported on WebGPU platform.
+ *
+ * Call {@link Compute#destroy} when no longer needed. The graphics device retains compute
+ * instances for device recovery until they are explicitly destroyed.
  */
 class Compute {
     /**

--- a/src/platform/graphics/storage-buffer.js
+++ b/src/platform/graphics/storage-buffer.js
@@ -100,7 +100,8 @@ class StorageBuffer {
      * possible. This has a performance impact, so it should be used only when necessary. Defaults
      * to false.
      * @returns {Promise<ArrayBufferView>} A promise that resolves with the data read from the
-     * storage buffer.
+     * storage buffer. Rejects with an `AbortError` if the read is cancelled, for example by device
+     * loss. Other read failures also reject the promise.
      */
     read(offset = 0, size = this.byteSize, data = null, immediate = false) {
         return this.impl.read(this.device, offset, size, data, immediate);

--- a/src/platform/graphics/webgpu/webgpu-compute.js
+++ b/src/platform/graphics/webgpu/webgpu-compute.js
@@ -82,17 +82,29 @@ class WebgpuCompute {
 
         // pipeline
         this.pipeline = device.computePipeline.get(shader, formats);
+        device._computes.add(this);
 
         DebugGraphics.popGpuMarker(device);
     }
 
     destroy() {
+        this.compute.device._computes.delete(this);
+        this.pipeline = null;
 
         this.uniformBuffers.forEach(ub => ub.destroy());
         this.uniformBuffers.length = 0;
 
         this.bindGroups.forEach(bindGroup => bindGroup.destroy());
         this.bindGroups.length = 0;
+    }
+
+    loseContext() {
+        this.pipeline = null;
+    }
+
+    restoreContext() {
+        const { device, shader } = this.compute;
+        this.pipeline = device.computePipeline.get(shader, this.bindGroups.map(bindGroup => bindGroup.format));
     }
 
     updateBindGroup() {

--- a/src/platform/graphics/webgpu/webgpu-draw-commands.js
+++ b/src/platform/graphics/webgpu/webgpu-draw-commands.js
@@ -27,11 +27,15 @@ class WebgpuDrawCommands {
      */
     storage = null;
 
+    /** @type {number} */
+    count = 0;
+
     /**
      * @param {GraphicsDevice} device - Graphics device.
      */
     constructor(device) {
         this.device = device;
+        device.on('devicerestored', this.restoreContext, this);
     }
 
     /**
@@ -44,6 +48,7 @@ class WebgpuDrawCommands {
             return;
         }
         this.storage?.destroy();
+        this.count = 0;
         this.gpuIndirect = new Uint32Array(5 * maxCount);
         this.gpuIndirectSigned = new Int32Array(this.gpuIndirect.buffer);
         this.storage = new StorageBuffer(this.device, this.gpuIndirect.byteLength, BUFFERUSAGE_INDIRECT | BUFFERUSAGE_COPY_DST);
@@ -73,6 +78,7 @@ class WebgpuDrawCommands {
      * @param {number} count - Number of active draws.
      */
     update(count) {
+        this.count = count;
         if (this.storage && count > 0) {
             const used = count * 5; // 5 uints per draw
             this.storage.write(0, this.gpuIndirect, 0, used);
@@ -103,7 +109,13 @@ class WebgpuDrawCommands {
     }
     // #endif
 
+    restoreContext() {
+        // The storage buffer is recreated empty, but CPU-authored commands are still available.
+        this.update(this.count);
+    }
+
     destroy() {
+        this.device.off('devicerestored', this.restoreContext, this);
         this.storage?.destroy();
         this.storage = null;
     }

--- a/src/platform/graphics/webgpu/webgpu-draw-commands.js
+++ b/src/platform/graphics/webgpu/webgpu-draw-commands.js
@@ -4,16 +4,17 @@ import { DebugHelper } from '../../../core/debug.js';
 import { getPrimitiveCount } from '../primitive-utils.js';
 
 /**
- * @import { GraphicsDevice } from '../graphics-device.js'
+ * @import { WebgpuGraphicsDevice } from './webgpu-graphics-device.js'
  */
 
 /**
  * WebGPU implementation of DrawCommands.
+ * Retained by the device for recovery until destroyed by the owning DrawCommands.
  *
  * @ignore
  */
 class WebgpuDrawCommands {
-    /** @type {GraphicsDevice} */
+    /** @type {WebgpuGraphicsDevice} */
     device;
 
     /** @type {Uint32Array|null} */
@@ -31,11 +32,11 @@ class WebgpuDrawCommands {
     count = 0;
 
     /**
-     * @param {GraphicsDevice} device - Graphics device.
+     * @param {WebgpuGraphicsDevice} device - Graphics device.
      */
     constructor(device) {
         this.device = device;
-        device.on('devicerestored', this.restoreContext, this);
+        device._drawCommands.add(this);
     }
 
     /**
@@ -115,7 +116,7 @@ class WebgpuDrawCommands {
     }
 
     destroy() {
-        this.device.off('devicerestored', this.restoreContext, this);
+        this.device._drawCommands.delete(this);
         this.storage?.destroy();
         this.storage = null;
     }

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -99,6 +99,15 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     _computes = new Set();
 
     /**
+     * Strong references used to restore CPU-authored draw commands. Owners must explicitly
+     * destroy draw commands when no longer needed to unregister them.
+     *
+     * @type {Set<WebgpuDrawCommands>}
+     * @private
+     */
+    _drawCommands = new Set();
+
+    /**
      * Object responsible for caching and creation of render pipelines.
      */
     renderPipeline = new WebgpuRenderPipeline(this);
@@ -764,6 +773,11 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         }
         // Bind groups rebuild through their normal dirty update after buffer allocations are ready.
         super.restoreContext();
+
+        // Reupload commands after their storage buffers have been recreated.
+        for (const drawCommands of this._drawCommands) {
+            drawCommands.restoreContext();
+        }
     }
 
     postInit() {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -90,6 +90,15 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     _bindGroupFormats = new Set();
 
     /**
+     * Strong references used to restore compute pipelines. Owners must explicitly destroy
+     * compute instances when no longer needed to unregister them.
+     *
+     * @type {Set<WebgpuCompute>}
+     * @private
+     */
+    _computes = new Set();
+
+    /**
      * Object responsible for caching and creation of render pipelines.
      */
     renderPipeline = new WebgpuRenderPipeline(this);
@@ -669,6 +678,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
             this._debugRestoreDelay = () => new Promise((resolve) => {
                 setTimeout(resolve, delay);
             });
+            // destroy() detaches mapped buffers immediately, before the asynchronous lost
+            // notification. Stop subsequent frames from allocating out of those buffers.
+            this.contextLost = true;
             this.wgpu.destroy();
         });
     }
@@ -729,6 +741,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         for (const format of this._bindGroupFormats) {
             format.loseContext();
         }
+        for (const compute of this._computes) {
+            compute.loseContext();
+        }
 
         for (const resource of this._deferredDestroys) {
             resource.destroy();
@@ -743,6 +758,9 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         }
         for (const format of this._bindGroupFormats) {
             format.restoreContext();
+        }
+        for (const compute of this._computes) {
+            compute.restoreContext();
         }
         // Bind groups rebuild through their normal dirty update after buffer allocations are ready.
         super.restoreContext();
@@ -1630,50 +1648,31 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
         return this.readBuffer(stagingBuffer, size, data, immediate);
     }
 
-    readBuffer(stagingBuffer, size, data = null, immediate = false) {
-
+    async readBuffer(stagingBuffer, size, data = null, immediate = false) {
         const destBuffer = stagingBuffer.buffer;
-
-        // return a promise that resolves with the data
-        return new Promise((resolve, reject) => {
-
-            const read = () => {
-
-                this.mapBufferAsync(destBuffer, GPUMapMode.READ).then((mapped) => {
-
-                    if (!mapped) {
-                        stagingBuffer.destroy(this);
-                        reject(new Error('Failed to map a staging buffer for reading, most likely because the device was lost.'));
-                        return;
-                    }
-
-                    // copy data to a buffer
-                    data ??= new Uint8Array(size);
-                    const copySrc = destBuffer.getMappedRange(0, size);
-
-                    // use the same type as the target
-                    const srcType = data.constructor;
-                    data.set(new srcType(copySrc));
-
-                    // release staging buffer
-                    destBuffer.unmap();
-                    stagingBuffer.destroy(this);
-
-                    resolve(data);
-                });
-            };
-
+        try {
             if (immediate) {
-                // submit the command buffer immediately
                 this.submit();
-                read();
             } else {
-                // map the buffer during the next event handling cycle, when the command buffer is submitted
-                setTimeout(() => {
-                    read();
+                // Wait until recorded copies have been submitted before mapping.
+                await new Promise((resolve) => {
+                    setTimeout(resolve);
                 });
             }
-        });
+
+            // Preserve the native AbortError so callers can distinguish interrupted reads,
+            // even when mapping rejects before the device-lost event arrives.
+            await destBuffer.mapAsync(GPUMapMode.READ);
+
+            data ??= new Uint8Array(size);
+            const copySrc = destBuffer.getMappedRange(0, size);
+            const srcType = data.constructor;
+            data.set(new srcType(copySrc));
+            return data;
+        } finally {
+            destBuffer.unmap();
+            stagingBuffer.destroy(this);
+        }
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-upload-stream.js
+++ b/src/platform/graphics/webgpu/webgpu-upload-stream.js
@@ -2,6 +2,7 @@ import { Debug, DebugHelper } from '../../../core/debug.js';
 
 /**
  * @import { UploadStream } from '../upload-stream.js'
+ * @import { WebgpuGraphicsDevice } from './webgpu-graphics-device.js'
  */
 
 let id = 0;
@@ -49,18 +50,20 @@ class WebgpuUploadStream {
 
     /**
      * Handles device lost event.
-     * TODO: Implement proper WebGPU device lost handling if needed.
      *
      * @protected
      */
     _onDeviceLost() {
-        // WebGPU device lost handling not yet implemented
+        this.availableStagingBuffers.forEach(buffer => buffer.destroy());
+        this.availableStagingBuffers.length = 0;
+        this.pendingStagingBuffers.forEach(buffer => buffer.destroy());
+        this.pendingStagingBuffers.length = 0;
+        this._lastUploadSubmitVersion = -1;
     }
 
     destroy() {
         this._destroyed = true;
-        this.availableStagingBuffers.forEach(buffer => buffer.destroy());
-        this.pendingStagingBuffers.forEach(buffer => buffer.destroy());
+        this._onDeviceLost();
     }
 
     /**
@@ -70,7 +73,8 @@ class WebgpuUploadStream {
      */
     update(minByteSize) {
 
-        const device = this.uploadStream.device;
+        const device = /** @type {WebgpuGraphicsDevice} */ (this.uploadStream.device);
+        const wgpu = device.wgpu;
 
         // map all pending buffers
         const pending = this.pendingStagingBuffers;
@@ -78,7 +82,7 @@ class WebgpuUploadStream {
             const buffer = pending[i];
             // @ts-ignore - mapBufferAsync is available on WebgpuGraphicsDevice
             device.mapBufferAsync(buffer, GPUMapMode.WRITE).then((mapped) => {
-                if (mapped && !this._destroyed) {
+                if (mapped && !this._destroyed && !device.contextLost && device.wgpu === wgpu) {
                     this.availableStagingBuffers.push(buffer);
                 } else {
                     // the buffer cannot be reused when the mapping fails (device lost) or when

--- a/src/scene/graphics/prefix-sum-kernel.js
+++ b/src/scene/graphics/prefix-sum-kernel.js
@@ -251,6 +251,8 @@ class PrefixSumKernel {
      */
     destroyPasses() {
         for (const pass of this.passes) {
+            pass.scanCompute.destroy();
+            pass.addBlockCompute?.destroy();
             pass.blockSumBuffer?.destroy();
         }
         this.passes.length = 0;

--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -196,6 +196,8 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
      */
     _destroyPasses() {
         for (const pass of this._passes) {
+            pass.histogramCompute.destroy();
+            pass.reorderCompute.destroy();
             pass.histogramCompute.shader?.destroy();
             pass.reorderCompute.shader?.destroy();
         }

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -295,6 +295,12 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
     destroy() {
         this._destroyBuffers();
 
+        this._globalHistCompute?.destroy();
+        this._scanCompute?.destroy();
+        for (const compute of this._binningComputes) {
+            compute.destroy();
+        }
+
         this._globalHistShader?.destroy();
         this._scanShader?.destroy();
         this._binningShader?.destroy();

--- a/src/scene/gsplat-unified/gsplat-interval-compaction.js
+++ b/src/scene/gsplat-unified/gsplat-interval-compaction.js
@@ -161,8 +161,10 @@ class GSplatIntervalCompaction {
         this.sortElementCountBuffer?.destroy();
 
         this._destroyCullPass();
+        this._scatterCompute?.destroy();
         this._scatterCompute?.shader?.destroy();
         this._scatterBindGroupFormat?.destroy();
+        this._writeIndirectArgsCompute?.destroy();
         this._writeIndirectArgsCompute?.shader?.destroy();
         this._writeArgsBindGroupFormat?.destroy();
 
@@ -182,10 +184,12 @@ class GSplatIntervalCompaction {
 
     /** @private */
     _destroyCullPass() {
+        this._cullComputePerspective?.destroy();
         this._cullComputePerspective?.shader?.destroy();
         this._cullBindGroupFormatPerspective?.destroy();
         this._cullComputePerspective = null;
         this._cullBindGroupFormatPerspective = null;
+        this._cullComputeFisheye?.destroy();
         this._cullComputeFisheye?.shader?.destroy();
         this._cullBindGroupFormatFisheye?.destroy();
         this._cullComputeFisheye = null;

--- a/src/scene/gsplat-unified/gsplat-projector.js
+++ b/src/scene/gsplat-unified/gsplat-projector.js
@@ -248,11 +248,13 @@ class GSplatProjector {
         this.binWeightsBuffer?.destroy();
 
         for (const compute of this._projectorComputes.values()) {
+            compute.destroy();
             compute.shader?.destroy();
         }
         this._projectorComputes.clear();
 
         this._projectorBindGroupFormat?.destroy();
+        this._writeIndirectArgsCompute?.destroy();
         this._writeIndirectArgsCompute?.shader?.destroy();
         this._writeArgsBindGroupFormat?.destroy();
 
@@ -362,6 +364,7 @@ class GSplatProjector {
      */
     _destroyProjectorComputes() {
         for (const compute of this._projectorComputes.values()) {
+            compute.destroy();
             compute.shader?.destroy();
         }
         this._projectorComputes.clear();

--- a/src/scene/gsplat/gsplat-sorter.js
+++ b/src/scene/gsplat/gsplat-sorter.js
@@ -33,6 +33,9 @@ class GSplatSorter extends EventHandler {
      */
     pendingSorted = null;
 
+    /** @type {number} */
+    count = 0;
+
     /**
      * @param {GraphicsDevice} device - The graphics device.
      * @param {import('../scene.js').Scene} [scene] - The scene to fire sort timing events on.
@@ -44,6 +47,14 @@ class GSplatSorter extends EventHandler {
         // PBO + texSubImage2D path on Chrome's renderer→GPU IPC for multi-MB
         // integer-format uploads. WebGPU keeps the staging path.
         this.uploadStream = new UploadStream(device, !device.isWebGPU);
+        this._deviceRestoredEvent = device.on('devicerestored', () => {
+            if (this.orderData) {
+                // Storage buffers lose their contents. Reuse the latest CPU order even when
+                // the camera has not moved enough to request another sort from the worker.
+                this.pendingSorted = { count: this.count, data: new Uint32Array(this.orderData) };
+                this.fire('updated');
+            }
+        });
 
         const messageHandler = (message) => {
             const msgData = message.data ?? message;
@@ -63,6 +74,7 @@ class GSplatSorter extends EventHandler {
             // Store result for deferred GPU upload. Only the latest result is kept,
             // avoiding redundant uploads when multiple worker messages arrive between frames.
             this.orderData = newOrder;
+            this.count = msgData.count;
             this.pendingSorted = {
                 count: msgData.count,
                 data: new Uint32Array(newOrder)
@@ -88,6 +100,7 @@ class GSplatSorter extends EventHandler {
     }
 
     destroy() {
+        this._deviceRestoredEvent.off();
         this.worker.terminate();
         this.worker = null;
         this.uploadStream.destroy();

--- a/test/framework/graphics/picker.test.mjs
+++ b/test/framework/graphics/picker.test.mjs
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+
+import { Picker } from '../../../src/framework/graphics/picker.js';
+
+describe('Picker readback cancellation', function () {
+    for (const [method, empty] of [['getSelectionAsync', []], ['getPointDepthAsync', null]]) {
+        it(`${method} returns no selection when a WebGL fence fails during native context loss`, async function () {
+            const picker = {
+                deviceValid: true,
+                device: { isContextLost: () => true },
+                renderTarget: { colorBuffer: {} },
+                depthBuffer: {},
+                _readTexture: () => Promise.reject(new Error('webgl clientWaitSync sync failed'))
+            };
+            expect(await Picker.prototype[method].call(picker, 0, 0)).to.deep.equal(empty);
+        });
+
+        for (const name of ['AbortError', 'OperationError']) {
+            it(`${method} ${name === 'AbortError' ? 'returns no selection for cancellation' : 'propagates unexpected failures'} before device loss is reported`, async function () {
+                const error = new DOMException('Mapping failed', name);
+                const picker = {
+                    deviceValid: true,
+                    device: { isContextLost: () => false },
+                    renderTarget: { colorBuffer: {} },
+                    depthBuffer: {},
+                    _readTexture: () => Promise.reject(error)
+                };
+                let result;
+                let rejection;
+                try {
+                    result = await Picker.prototype[method].call(picker, 0, 0);
+                } catch (error) {
+                    rejection = error;
+                }
+                if (name === 'AbortError') {
+                    expect(rejection).to.equal(undefined);
+                    expect(result).to.deep.equal(empty);
+                } else {
+                    expect(rejection).to.equal(error);
+                }
+            });
+        }
+    }
+});

--- a/test/platform/graphics/primitive-count.test.mjs
+++ b/test/platform/graphics/primitive-count.test.mjs
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { restore, spy, stub } from 'sinon';
 
+import { EventHandler } from '../../../src/core/event-handler.js';
 import {
     PRIMITIVE_POINTS, PRIMITIVE_LINES, PRIMITIVE_LINELOOP, PRIMITIVE_LINESTRIP,
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRISTRIP, PRIMITIVE_TRIFAN
@@ -46,7 +47,7 @@ describe('Primitive counting', function () {
             let draw;
 
             beforeEach(function () {
-                device = {
+                device = Object.assign(new EventHandler(), {
                     _primitiveCount: 0,
                     _drawCallsPerFrame: 0,
                     shader: { ready: true, impl: { samplers: [], uniforms: [] } },
@@ -61,7 +62,7 @@ describe('Primitive counting', function () {
                     _vram: { sb: 0 },
                     buffers: new Set(),
                     createBufferImpl: () => ({ buffer: {}, allocate() {}, write() {}, destroy() {} })
-                };
+                });
                 const webgl = backend === 'WebGL';
                 device.createDrawCommandImpl = () => (webgl ? new WebglDrawCommands(0) : new WebgpuDrawCommands(device));
                 commands = new DrawCommands(device);

--- a/test/platform/graphics/primitive-count.test.mjs
+++ b/test/platform/graphics/primitive-count.test.mjs
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { restore, spy, stub } from 'sinon';
 
-import { EventHandler } from '../../../src/core/event-handler.js';
 import {
     PRIMITIVE_POINTS, PRIMITIVE_LINES, PRIMITIVE_LINELOOP, PRIMITIVE_LINESTRIP,
     PRIMITIVE_TRIANGLES, PRIMITIVE_TRISTRIP, PRIMITIVE_TRIFAN
@@ -47,7 +46,7 @@ describe('Primitive counting', function () {
             let draw;
 
             beforeEach(function () {
-                device = Object.assign(new EventHandler(), {
+                device = {
                     _primitiveCount: 0,
                     _drawCallsPerFrame: 0,
                     shader: { ready: true, impl: { samplers: [], uniforms: [] } },
@@ -61,8 +60,9 @@ describe('Primitive counting', function () {
                     passEncoder: { draw() {}, drawIndirect() {} },
                     _vram: { sb: 0 },
                     buffers: new Set(),
+                    _drawCommands: new Set(),
                     createBufferImpl: () => ({ buffer: {}, allocate() {}, write() {}, destroy() {} })
-                });
+                };
                 const webgl = backend === 'WebGL';
                 device.createDrawCommandImpl = () => (webgl ? new WebglDrawCommands(0) : new WebgpuDrawCommands(device));
                 commands = new DrawCommands(device);

--- a/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
@@ -3,17 +3,89 @@ import sinon from 'sinon';
 
 import { BindGroupFormat } from '../../../../src/platform/graphics/bind-group-format.js';
 import { BindGroup } from '../../../../src/platform/graphics/bind-group.js';
+import { Compute } from '../../../../src/platform/graphics/compute.js';
 import { SHADERLANGUAGE_WGSL } from '../../../../src/platform/graphics/constants.js';
 import { GpuProfiler } from '../../../../src/platform/graphics/gpu-profiler.js';
 import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
 import { WebgpuBindGroupFormat } from '../../../../src/platform/graphics/webgpu/webgpu-bind-group-format.js';
 import { WebgpuBindGroup } from '../../../../src/platform/graphics/webgpu/webgpu-bind-group.js';
+import { WebgpuComputePipeline } from '../../../../src/platform/graphics/webgpu/webgpu-compute-pipeline.js';
+import { WebgpuCompute } from '../../../../src/platform/graphics/webgpu/webgpu-compute.js';
 import { WebgpuDynamicBuffers } from '../../../../src/platform/graphics/webgpu/webgpu-dynamic-buffers.js';
 import { WebgpuGraphicsDevice } from '../../../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
 import { WebgpuShaderProcessorWGSL } from '../../../../src/platform/graphics/webgpu/webgpu-shader-processor-wgsl.js';
 import { WebgpuShader } from '../../../../src/platform/graphics/webgpu/webgpu-shader.js';
 
 describe('WebGPU context restoration', function () {
+    it('stops rendering before debug destruction detaches mapped buffers', function () {
+        const device = {
+            contextLost: false,
+            wgpu: { destroy: sinon.spy(() => expect(device.contextLost).to.be.true) }
+        };
+        WebgpuGraphicsDevice.prototype.debugLoseContext.call(device, 100);
+        expect(device.wgpu.destroy.calledOnce).to.be.true;
+        WebgpuGraphicsDevice.prototype.debugLoseContext.call(device, 100);
+        expect(device.wgpu.destroy.calledOnce).to.be.true;
+    });
+
+    it('restores shared compute pipelines before dispatch and unregisters destroyed computes', function () {
+        const device = new NullGraphicsDevice({ width: 1, height: 1 });
+        const createDevice = () => ({
+            createBindGroupLayout: desc => ({ desc }),
+            createPipelineLayout: desc => ({ desc }),
+            createComputePipeline: sinon.spy(desc => ({ desc })),
+            pushErrorScope() {},
+            popErrorScope: () => Promise.resolve(null)
+        });
+        device.wgpu = createDevice();
+        device.supportsCompute = true;
+        device._bindGroups = new Set();
+        device._bindGroupFormats = new Set();
+        device._computes = new Set();
+        device.commandBuffers = [];
+        device.bindGroupFormats = [];
+        device._deferredDestroys = [];
+        device.renderPipeline = { cache: new Map() };
+        device.computePipeline = new WebgpuComputePipeline(device);
+        device.destroyDeviceResources = () => {};
+        device.createBindGroupFormatImpl = format => new WebgpuBindGroupFormat(format);
+        device.createBindGroupImpl = bindGroup => new WebgpuBindGroup(bindGroup);
+        device.createComputeImpl = compute => new WebgpuCompute(compute);
+        const format = new BindGroupFormat(device, []);
+        const shader = { impl: {
+            computeBindGroupFormat: format,
+            computeKey: 1,
+            getComputeShaderModule: () => ({}),
+            computeEntryPoint: 'main'
+        } };
+        const first = new Compute(device, shader);
+        const second = new Compute(device, shader);
+        const oldPipeline = first.impl.pipeline;
+        expect(second.impl.pipeline).to.equal(oldPipeline);
+        expect(device.wgpu.createComputePipeline.calledOnce).to.be.true;
+
+        for (let cycle = 0; cycle < 2; cycle++) {
+            WebgpuGraphicsDevice.prototype.loseContext.call(device);
+            expect(first.impl.pipeline).to.equal(null);
+            expect(second.impl.pipeline).to.equal(null);
+            device.wgpu = createDevice();
+            WebgpuGraphicsDevice.prototype.restoreContext.call(device);
+            expect(first.impl.pipeline).not.to.equal(oldPipeline);
+            expect(second.impl.pipeline).to.equal(first.impl.pipeline);
+            expect(first.impl.pipeline.desc.layout.desc.bindGroupLayouts[0]).to.equal(format.impl.bindGroupLayout);
+            expect(device.wgpu.createComputePipeline.calledOnce).to.be.true;
+            device.passEncoder = { setPipeline: sinon.spy(), dispatchWorkgroups() {} };
+            first.impl.dispatch(1, 1, 1);
+            expect(device.passEncoder.setPipeline.calledOnceWithExactly(first.impl.pipeline)).to.be.true;
+        }
+
+        first.destroy();
+        second.destroy();
+        expect(device._computes.size).to.equal(0);
+        format.destroy();
+        device.destroy();
+    });
+
     for (const enabled of [true, false]) {
         it(`preserves the requested profiler enabled state (${enabled}) on recovery`, async function () {
             const device = {
@@ -85,6 +157,7 @@ describe('WebGPU context restoration', function () {
         device.wgpu = createDevice();
         device._bindGroups = new Set();
         device._bindGroupFormats = new Set();
+        device._computes = new Set();
         device.createBindGroupFormatImpl = format => new WebgpuBindGroupFormat(format);
         device.createBindGroupImpl = bindGroup => new WebgpuBindGroup(bindGroup);
         const format = new BindGroupFormat(device, []);

--- a/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-context-restore.test.mjs
@@ -42,6 +42,7 @@ describe('WebGPU context restoration', function () {
         device._bindGroups = new Set();
         device._bindGroupFormats = new Set();
         device._computes = new Set();
+        device._drawCommands = new Set();
         device.commandBuffers = [];
         device.bindGroupFormats = [];
         device._deferredDestroys = [];
@@ -158,6 +159,7 @@ describe('WebGPU context restoration', function () {
         device._bindGroups = new Set();
         device._bindGroupFormats = new Set();
         device._computes = new Set();
+        device._drawCommands = new Set();
         device.createBindGroupFormatImpl = format => new WebgpuBindGroupFormat(format);
         device.createBindGroupImpl = bindGroup => new WebgpuBindGroup(bindGroup);
         const format = new BindGroupFormat(device, []);

--- a/test/platform/graphics/webgpu/webgpu-draw-commands.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-draw-commands.test.mjs
@@ -1,14 +1,26 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { EventHandler } from '../../../../src/core/event-handler.js';
+import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
 import { WebgpuDrawCommands } from '../../../../src/platform/graphics/webgpu/webgpu-draw-commands.js';
+import { WebgpuGraphicsDevice } from '../../../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
 
 describe('WebGPU draw command recovery', function () {
-    it('reuploads active CPU commands after each restoration and removes its listener on destruction', function () {
-        const device = new EventHandler();
+    it('reuploads commands after buffer restoration and unregisters them on destruction', function () {
+        const device = new NullGraphicsDevice({ width: 1, height: 1 });
+        device._bindGroupFormats = new Set();
+        device._computes = new Set();
+        device._drawCommands = new Set();
         const commands = new WebgpuDrawCommands(device);
-        const storage = { write: sinon.spy(), destroy: sinon.spy() };
+        let bufferReady = true;
+        const storage = {
+            restoreContext() {
+                bufferReady = true;
+            },
+            write: sinon.spy(() => expect(bufferReady).to.be.true),
+            destroy: sinon.spy(() => device.buffers.delete(storage))
+        };
+        device.buffers.add(storage);
         commands.storage = storage;
         commands.gpuIndirect = new Uint32Array(10);
         commands.gpuIndirectSigned = new Int32Array(commands.gpuIndirect.buffer);
@@ -16,16 +28,22 @@ describe('WebGPU draw command recovery', function () {
         commands.update(1);
         storage.write.resetHistory();
 
-        device.fire('devicerestored');
-        device.fire('devicerestored');
+        expect(device._drawCommands.has(commands)).to.be.true;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+        for (let cycle = 1; cycle <= 2; cycle++) {
+            bufferReady = false;
+            WebgpuGraphicsDevice.prototype.restoreContext.call(device);
+            expect(storage.write.callCount).to.equal(cycle);
+        }
         expect(storage.write.callCount).to.equal(2);
         expect(storage.write.alwaysCalledWithExactly(0, commands.gpuIndirect, 0, 5)).to.be.true;
         expect([...commands.gpuIndirectSigned.subarray(0, 5)]).to.deep.equal([36, 12, 3, -2, 7]);
 
         commands.destroy();
-        device.fire('devicerestored');
+        expect(device._drawCommands.size).to.equal(0);
+        WebgpuGraphicsDevice.prototype.restoreContext.call(device);
         expect(storage.write.callCount).to.equal(2);
         expect(storage.destroy.calledOnce).to.be.true;
-        expect(device.hasEvent('devicerestored')).to.be.false;
+        device.destroy();
     });
 });

--- a/test/platform/graphics/webgpu/webgpu-draw-commands.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-draw-commands.test.mjs
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { EventHandler } from '../../../../src/core/event-handler.js';
+import { WebgpuDrawCommands } from '../../../../src/platform/graphics/webgpu/webgpu-draw-commands.js';
+
+describe('WebGPU draw command recovery', function () {
+    it('reuploads active CPU commands after each restoration and removes its listener on destruction', function () {
+        const device = new EventHandler();
+        const commands = new WebgpuDrawCommands(device);
+        const storage = { write: sinon.spy(), destroy: sinon.spy() };
+        commands.storage = storage;
+        commands.gpuIndirect = new Uint32Array(10);
+        commands.gpuIndirectSigned = new Int32Array(commands.gpuIndirect.buffer);
+        commands.add(0, 36, 12, 3, -2, 7);
+        commands.update(1);
+        storage.write.resetHistory();
+
+        device.fire('devicerestored');
+        device.fire('devicerestored');
+        expect(storage.write.callCount).to.equal(2);
+        expect(storage.write.alwaysCalledWithExactly(0, commands.gpuIndirect, 0, 5)).to.be.true;
+        expect([...commands.gpuIndirectSigned.subarray(0, 5)]).to.deep.equal([36, 12, 3, -2, 7]);
+
+        commands.destroy();
+        device.fire('devicerestored');
+        expect(storage.write.callCount).to.equal(2);
+        expect(storage.destroy.calledOnce).to.be.true;
+        expect(device.hasEvent('devicerestored')).to.be.false;
+    });
+});

--- a/test/platform/graphics/webgpu/webgpu-read-buffer.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-read-buffer.test.mjs
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { WebgpuGraphicsDevice } from '../../../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
+
+describe('WebGPU buffer readback', function () {
+    const originalMapMode = globalThis.GPUMapMode;
+
+    before(function () {
+        globalThis.GPUMapMode = { READ: 1 };
+    });
+
+    after(function () {
+        if (originalMapMode === undefined) {
+            delete globalThis.GPUMapMode;
+        } else {
+            globalThis.GPUMapMode = originalMapMode;
+        }
+    });
+
+    it('copies a mapped result into the caller array and releases the staging buffer', async function () {
+        const source = new Uint32Array([3, 5]);
+        const destination = new Uint32Array(2);
+        const buffer = {
+            mapAsync: sinon.stub().resolves(),
+            getMappedRange: sinon.stub().returns(source.buffer),
+            unmap: sinon.spy()
+        };
+        const staging = { buffer, destroy: sinon.spy() };
+        const device = { submit: sinon.spy() };
+        const result = await WebgpuGraphicsDevice.prototype.readBuffer.call(device, staging, 8, destination, true);
+        expect(result).to.equal(destination);
+        expect([...result]).to.deep.equal([3, 5]);
+        expect(device.submit.calledBefore(buffer.mapAsync)).to.be.true;
+        expect(buffer.unmap.calledOnce).to.be.true;
+        expect(staging.destroy.calledOnceWithExactly(device)).to.be.true;
+    });
+
+    for (const name of ['AbortError', 'OperationError']) {
+        it(`preserves ${name} before the device-lost event and releases the staging buffer`, async function () {
+            const error = new DOMException('Mapping failed', name);
+            const buffer = { mapAsync: sinon.stub().rejects(error), unmap: sinon.spy() };
+            const staging = { buffer, destroy: sinon.spy() };
+            const device = { contextLost: false };
+            let rejection;
+            try {
+                await WebgpuGraphicsDevice.prototype.readBuffer.call(device, staging, 8);
+            } catch (error) {
+                rejection = error;
+            }
+            expect(rejection).to.equal(error);
+            expect(buffer.unmap.calledOnce).to.be.true;
+            expect(staging.destroy.calledOnceWithExactly(device)).to.be.true;
+        });
+    }
+
+    it('rejects and cleans up when copying the mapped result fails', async function () {
+        const error = new Error('Mapped range unavailable');
+        const buffer = {
+            mapAsync: sinon.stub().resolves(),
+            getMappedRange: sinon.stub().throws(error),
+            unmap: sinon.spy()
+        };
+        const staging = { buffer, destroy: sinon.spy() };
+        let rejection;
+        try {
+            await WebgpuGraphicsDevice.prototype.readBuffer.call({}, staging, 8);
+        } catch (error) {
+            rejection = error;
+        }
+        expect(rejection).to.equal(error);
+        expect(buffer.unmap.calledOnce).to.be.true;
+        expect(staging.destroy.calledOnce).to.be.true;
+    });
+});

--- a/test/platform/graphics/webgpu/webgpu-upload-stream.test.mjs
+++ b/test/platform/graphics/webgpu/webgpu-upload-stream.test.mjs
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { WebgpuUploadStream } from '../../../../src/platform/graphics/webgpu/webgpu-upload-stream.js';
+
+describe('WebGPU upload stream recovery', function () {
+    const originalMapMode = globalThis.GPUMapMode;
+    before(function () {
+        globalThis.GPUMapMode = { WRITE: 2 };
+    });
+    after(function () {
+        if (originalMapMode === undefined) delete globalThis.GPUMapMode;
+        else globalThis.GPUMapMode = originalMapMode;
+    });
+
+    it('discards pooled buffers and excludes a late mapping from the replacement device pool', async function () {
+        let completeMapping;
+        const device = { wgpu: {},
+            mapBufferAsync: () => new Promise((resolve) => {
+                completeMapping = resolve;
+            }) };
+        const stream = new WebgpuUploadStream({ device });
+        const available = { size: 16, destroy: sinon.spy() };
+        const pending = { size: 16, destroy: sinon.spy() };
+        const mapping = { size: 16, destroy: sinon.spy() };
+        stream.pendingStagingBuffers.push(mapping);
+        stream.update(16);
+        stream.availableStagingBuffers.push(available);
+        stream.pendingStagingBuffers.push(pending);
+        stream._lastUploadSubmitVersion = 42;
+        stream._onDeviceLost();
+        device.wgpu = {};
+        completeMapping(true);
+        await Promise.resolve();
+        expect(stream.availableStagingBuffers).to.have.lengthOf(0);
+        expect(stream.pendingStagingBuffers).to.have.lengthOf(0);
+        expect(stream._lastUploadSubmitVersion).to.equal(-1);
+        for (const buffer of [available, pending, mapping]) expect(buffer.destroy.calledOnce).to.be.true;
+        stream.destroy();
+        for (const buffer of [available, pending, mapping]) expect(buffer.destroy.calledOnce).to.be.true;
+    });
+});

--- a/test/scene/gsplat-sorter.test.mjs
+++ b/test/scene/gsplat-sorter.test.mjs
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { EventHandler } from '../../src/core/event-handler.js';
+import { GSplatSorter } from '../../src/scene/gsplat/gsplat-sorter.js';
+
+describe('GSplatSorter recovery', function () {
+    it('reuploads the latest order without a new camera update and detaches its listener on destruction', function () {
+        const originalWorker = globalThis.Worker;
+        globalThis.Worker = class {
+            on(event, handler) {
+                this.handler = handler;
+            }
+
+            postMessage() {}
+
+            terminate() {}
+        };
+        const device = new EventHandler();
+        device.isWebGPU = true;
+        const upload = sinon.spy();
+        device.createUploadStreamImpl = () => ({ upload, destroy() {} });
+        let sorter;
+        try {
+            sorter = new GSplatSorter(device);
+            const target = {};
+            sorter.init(target, 3, new Float32Array(9));
+            const order = new Uint32Array([2, 0, 1]);
+            sorter.worker.handler({ order: order.buffer, count: 3 });
+            expect(sorter.applyPendingSorted()).to.equal(3);
+            expect(sorter.applyPendingSorted()).to.equal(-1);
+            const updated = sinon.spy();
+            sorter.on('updated', updated);
+
+            device.fire('devicelost');
+            device.fire('devicerestored');
+            expect(updated.calledOnce).to.be.true;
+            expect(sorter.applyPendingSorted()).to.equal(3);
+            expect(upload.calledTwice).to.be.true;
+            expect(upload.lastCall.args[0].buffer).to.equal(order.buffer);
+            expect([...upload.lastCall.args[0]]).to.deep.equal([2, 0, 1]);
+            expect(upload.lastCall.args[1]).to.equal(target);
+
+            sorter.destroy();
+            sorter = null;
+            device.fire('devicerestored');
+            expect(updated.calledOnce).to.be.true;
+        } finally {
+            sorter?.destroy();
+            if (originalWorker === undefined) delete globalThis.Worker;
+            else globalThis.Worker = originalWorker;
+        }
+    });
+});


### PR DESCRIPTION
Fix device-loss failures that left compute work using stale pipelines, multi-draw geometry missing, splats incorrectly ordered, or asynchronous reads reporting errors after recovery.

Closes #6171.

**Changes:**
- Restore compute pipelines and release obsolete compute instances before their shaders and binding formats are destroyed.
- Restore CPU-authored indirect draw commands and retained splat sort order.
- Discard upload buffers belonging to the lost device and prevent reuse through late mapping callbacks.
- Release readback buffers on every outcome and handle interrupted picking on WebGPU and WebGL.
- Repopulate GPU-generated example data after restoration and ignore stale asynchronous results.

**API behavior:**
- Cancelled `StorageBuffer.read()` calls preserve `AbortError`; other failures still reject.
- Document that unused `Compute` instances must be explicitly destroyed.

**Examples:**
- Update histogram, direct and indirect radix sorting, and texture-copy recovery.
- Include the required splat component system in the scene-depth test.

**Performance:**
Recovery uses lifecycle callbacks without adding device-identity checks to draw or dispatch paths.

Validation completed across all 268 example routes: 264 recovered and four disable WebGPU. Eight examples restart GPU-only particle or paint history. XR checks cover desktop previews; hierarchy used paced frame submission. All 2,817 unit tests passed, with two pending, alongside lint, formatting, type generation, and targeted WebGL checks.

