### PR TITLE
Fix StandardMaterial shader invalidation for environment textures and 0/1 number changes

### DIFF
--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -768,10 +768,20 @@ class StandardMaterial extends Material {
         });
     }
 
-    _processParameters(paramsName) {
+    /**
+     * Replaces the set of parameters published by one update path with the parameters published
+     * since the previous call, deleting the ones that were dropped. A parameter that the other
+     * update path currently publishes is kept: material and scene environment textures share
+     * uniform names, so it would otherwise delete a value the other path has just set.
+     *
+     * @param {string} paramsName - The name of the tracked set to update.
+     * @param {Set<string>} otherParams - The set tracked by the other update path.
+     * @private
+     */
+    _processParameters(paramsName, otherParams) {
         const prevParams = this[paramsName];
         prevParams.forEach((param) => {
-            if (!_params.has(param)) {
+            if (!_params.has(param) && !otherParams.has(param)) {
                 delete this.parameters[param];
             }
         });
@@ -952,7 +962,7 @@ class StandardMaterial extends Material {
         this._setParameter('material_reflectivity', this.reflectivity);
 
         // remove unused params
-        this._processParameters('_activeParams');
+        this._processParameters('_activeParams', this._activeLightingParams);
 
         // Clear variants dirtied by compatibility processing above.
         super.updateUniforms(device, scene);
@@ -972,7 +982,7 @@ class StandardMaterial extends Material {
             }
         }
 
-        this._processParameters('_activeLightingParams');
+        this._processParameters('_activeLightingParams', this._activeParams);
     }
 
     /** @ignore */
@@ -1327,24 +1337,31 @@ function _defineFloat(name, defaultValue, getUniformFunc) {
         name: name,
         defaultValue: defaultValue,
         dirtyShaderFunc: (oldValue, newValue) => {
-            // This is not always optimal and will sometimes trigger redundant shader
-            // recompilation. However, no number property on a standard material
-            // triggers a shader recompile if the previous and current values both
-            // have a fractional part.
-            return (oldValue === 0 || oldValue === 1) !== (newValue === 0 || newValue === 1);
+            // Shader options only ever depend on a number property being 0 or 1 (e.g. metalness < 1,
+            // clearCoat > 0), so a change involving either of those values may need a new shader,
+            // including a direct 0 <-> 1 change. This is not always optimal and will sometimes trigger
+            // a redundant shader recompilation, but a change between two fractional values never does.
+            return oldValue === 0 || oldValue === 1 || newValue === 0 || newValue === 1;
         }
     });
 
     defineUniform(name, getUniformFunc);
 }
 
-function _defineObject(name, getUniformFunc) {
+// Adding or removing an object selects different shader code (e.g. the reflection or ambient
+// source), while replacing one object with another only changes uniform data.
+const dirtyShaderOnPresence = (oldValue, newValue) => !!oldValue !== !!newValue;
+
+// Environment textures additionally need a different decode when the encoding changes.
+const dirtyShaderOnEnvTexture = (oldValue, newValue) => {
+    return !!oldValue !== !!newValue || (!!oldValue && !!newValue && oldValue.encoding !== newValue.encoding);
+};
+
+function _defineObject(name, getUniformFunc, dirtyShaderFunc = dirtyShaderOnPresence) {
     defineProp({
         name: name,
         defaultValue: null,
-        dirtyShaderFunc: (oldValue, newValue) => {
-            return !!oldValue === !!newValue;
-        }
+        dirtyShaderFunc: dirtyShaderFunc
     });
 
     defineUniform(name, getUniformFunc);
@@ -1444,6 +1461,7 @@ function _defineMaterialProps() {
 
     _defineObject('ambientSH');
 
+    // the box only feeds uniforms, the projection mode flag selects the shader code
     _defineObject('cubeMapProjectionBox', (material, device, scene) => {
         const uniform = material._allocUniform('cubeMapProjectionBox', () => {
             return [{
@@ -1468,7 +1486,7 @@ function _defineMaterialProps() {
         maxUniform[2] = bboxMax.z;
 
         return uniform;
-    });
+    }, () => false);
 
     _defineFlag('specularityFactorTint', false);
     _defineFlag('useMetalness', false);
@@ -1529,9 +1547,9 @@ function _defineMaterialProps() {
     _defineFlag('diffuseDetailMode', DETAILMODE_MUL);
     _defineFlag('aoDetailMode', DETAILMODE_MUL);
 
-    _defineObject('cubeMap');
-    _defineObject('sphereMap');
-    _defineObject('envAtlas');
+    _defineObject('cubeMap', undefined, dirtyShaderOnEnvTexture);
+    _defineObject('sphereMap', undefined, dirtyShaderOnEnvTexture);
+    _defineObject('envAtlas', undefined, dirtyShaderOnEnvTexture);
 
     // prefiltered cubemap getter
     const getterFunc = function () {

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { Color } from '../../../src/core/math/color.js';
 import { Vec2 } from '../../../src/core/math/vec2.js';
+import { BoundingBox } from '../../../src/core/shape/bounding-box.js';
 import { CUBEPROJ_NONE, DETAILMODE_MUL, DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO } from '../../../src/scene/constants.js';
 import { Material } from '../../../src/scene/materials/material.js';
 import { StandardMaterialOptions } from '../../../src/scene/materials/standard-material-options.js';
@@ -463,6 +464,117 @@ describe('StandardMaterial', function () {
             expect(material.variants.get(1)).to.equal(variant);
         });
 
+        it('invalidates shaders when a number property moves between 0 and 1', function () {
+            for (const [name, from, to] of [
+                ['refraction', 0, 1],
+                ['refraction', 1, 0],
+                ['metalness', 1, 0],
+                ['clearCoat', 0, 1],
+                ['clearCoat', 0, 0.5]
+            ]) {
+                const material = new StandardMaterial();
+                material[name] = from;
+                material.update();
+                addVariant(material);
+
+                material[name] = to;
+                material.update();
+                expect(material.variants.size, `${name} ${from} -> ${to}`).to.equal(0);
+            }
+        });
+
+        it('does not invalidate shaders when a number property changes between fractional values', function () {
+            const material = new StandardMaterial();
+            material.metalness = 0.3;
+            material.clearCoat = 0.3;
+            material.update();
+            const variant = addVariant(material);
+
+            material.metalness = 0.7;
+            material.clearCoat = 0.7;
+            material.update();
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
+        const envTexture = encoding => ({ encoding });
+
+        it('invalidates shaders when an environment texture is added or removed', function () {
+            for (const name of ['envAtlas', 'cubeMap', 'sphereMap']) {
+                const material = new StandardMaterial();
+                material.update();
+
+                addVariant(material);
+                material[name] = envTexture('rgbm');
+                material.update();
+                expect(material.variants.size, `${name} added`).to.equal(0);
+
+                addVariant(material);
+                material[name] = null;
+                material.update();
+                expect(material.variants.size, `${name} removed`).to.equal(0);
+            }
+        });
+
+        it('does not invalidate shaders when an environment texture is replaced with the same encoding', function () {
+            for (const name of ['envAtlas', 'cubeMap', 'sphereMap']) {
+                const material = new StandardMaterial();
+                material[name] = envTexture('rgbm');
+                material.update();
+                const variant = addVariant(material);
+
+                material[name] = envTexture('rgbm');
+                material.update();
+                expect(material.variants.get(1), name).to.equal(variant);
+            }
+        });
+
+        it('invalidates shaders when an environment texture is replaced with a different encoding', function () {
+            for (const name of ['envAtlas', 'cubeMap', 'sphereMap']) {
+                const material = new StandardMaterial();
+                material[name] = envTexture('rgbm');
+                material.update();
+                addVariant(material);
+
+                material[name] = envTexture('rgbp');
+                material.update();
+                expect(material.variants.size, name).to.equal(0);
+            }
+        });
+
+        it('invalidates shaders when ambient SH is added or removed but not when replaced', function () {
+            const material = new StandardMaterial();
+            material.update();
+            addVariant(material);
+
+            material.ambientSH = new Float32Array(27);
+            material.update();
+            expect(material.variants.size).to.equal(0);
+
+            const variant = addVariant(material);
+            material.ambientSH = new Float32Array(27);
+            material.update();
+            expect(material.variants.get(1)).to.equal(variant);
+
+            material.ambientSH = null;
+            material.update();
+            expect(material.variants.size).to.equal(0);
+        });
+
+        it('does not invalidate shaders when the cube map projection box changes', function () {
+            const material = new StandardMaterial();
+            material.update();
+            const variant = addVariant(material);
+
+            material.cubeMapProjectionBox = new BoundingBox();
+            material.update();
+            material.cubeMapProjectionBox = new BoundingBox();
+            material.update();
+            material.cubeMapProjectionBox = null;
+            material.update();
+
+            expect(material.variants.get(1)).to.equal(variant);
+        });
+
         it('invalidates shaders when an in-place specular change enables specular shading', function () {
             const material = new StandardMaterial();
             const specular = material.specular;
@@ -605,6 +717,67 @@ describe('StandardMaterial', function () {
             expect(material.variants.size).to.equal(0);
         });
 
+    });
+
+    describe('#updateEnvUniforms()', function () {
+        const envTexture = name => ({ name, encoding: 'rgbm' });
+        const scene = { envAtlas: envTexture('sceneAtlas'), skybox: envTexture('sceneSkybox') };
+
+        // mirrors the renderer: the version-gated uniform update, then the shader variant request
+        const prepare = (material) => {
+            material.updateUniforms(null, scene);
+            material.updateEnvUniforms(null, scene);
+        };
+
+        it('publishes the scene environment textures when the material has none', function () {
+            const material = new StandardMaterial();
+            material.update();
+            prepare(material);
+
+            expect(material.getParameter('texture_envAtlas').data).to.equal(scene.envAtlas);
+            expect(material.getParameter('texture_cubeMap').data).to.equal(scene.skybox);
+        });
+
+        it('keeps a material environment texture published when it replaces the scene one', function () {
+            const material = new StandardMaterial();
+            material.update();
+            prepare(material);
+
+            const atlas = envTexture('materialAtlas');
+            material.envAtlas = atlas;
+            material.update();
+            prepare(material);
+
+            expect(material.getParameter('texture_envAtlas').data).to.equal(atlas);
+            expect(material.getParameter('texture_cubeMap')).to.be.undefined;
+        });
+
+        it('publishes the scene environment textures again when the material texture is removed', function () {
+            const material = new StandardMaterial();
+            material.envAtlas = envTexture('materialAtlas');
+            material.update();
+            prepare(material);
+
+            material.envAtlas = null;
+            material.update();
+            prepare(material);
+
+            expect(material.getParameter('texture_envAtlas').data).to.equal(scene.envAtlas);
+            expect(material.getParameter('texture_cubeMap').data).to.equal(scene.skybox);
+        });
+
+        it('drops the scene environment textures when useSkybox is disabled', function () {
+            const material = new StandardMaterial();
+            material.update();
+            prepare(material);
+
+            material.useSkybox = false;
+            material.update();
+            prepare(material);
+
+            expect(material.getParameter('texture_envAtlas')).to.be.undefined;
+            expect(material.getParameter('texture_cubeMap')).to.be.undefined;
+        });
     });
 
     describe('shader generation', function () {


### PR DESCRIPTION
## Description
`StandardMaterial` decides whether a property change needs new shader variants from small per-property heuristics in its property definitions. Three of them let a material keep rendering with a stale shader:

- **`_defineObject`** (`envAtlas`, `cubeMap`, `sphereMap`, `ambientSH`, `cubeMapProjectionBox`) returned `!!old === !!new`: adding or removing an environment texture never invalidated the variants, while replacing one texture with another always did. Presence selects the reflection / ambient source, so it must invalidate; a swap only needs to when the encoding changes; the projection box only feeds uniforms. Each property now uses a matching rule.
- **`_defineFloat`** returned `(old is 0|1) !== (new is 0|1)`, which never fires for a direct 0 ↔ 1 change, although the shader options key off exactly those values (`metalness < 1`, `clearCoat > 0`, `refraction`). `metalness = 0`, `refraction = 1` or `clearCoat = 1` from their defaults kept the previous shader until an unrelated change happened to rebuild it. The rule now invalidates whenever either value is 0 or 1 and still skips changes between two fractional values.
- **`updateUniforms` / `updateEnvUniforms`** prune the parameters they published against two separate sets while sharing the `texture_envAtlas` / `texture_cubeMap` names. On the first variant rebuild after a material switched from the scene environment to its own, the lighting prune deleted the texture the material had just published, and the shader sampled whatever the previous draw call had left in the scope. Pruning now keeps a name the other path currently publishes.

Found while building the environment sources test example (https://github.com/playcanvas/engine/pull/9360).

## Public API changes
None.

## Testing
- 11 new unit tests in `test/scene/materials/standard-material.test.mjs`: presence / encoding invalidation for the environment textures and SH, 0 ↔ 1 number changes, and scene ↔ material environment texture transitions (one of them fails without the prune guard).
- `npm test` under Node 22: 2762 passing.
- Verified in the browser on WebGL2 and WebGPU with the test example: environment toggles, `metalness 1 → 0` and `refraction 0 ↔ 1` now rebuild immediately and the material's own textures stay bound across rebuilds.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
