### PR TITLE
Add collapsible MiniStats sections

### DIFF
--- a/examples/src/examples/debug/mini-stats.example.mjs
+++ b/examples/src/examples/debug/mini-stats.example.mjs
@@ -3,7 +3,7 @@
 //
 // Watch a field of objects build and dissolve as entities, materials, vertex buffers and textures
 // are allocated and released. A user counter plots a sine wave independently of the engine stats.
-// Click the MiniStats panel to cycle through its three views.
+// Click category headings to collapse or expand them, or elsewhere to cycle through three views.
 
 import {
     AppBase,
@@ -61,6 +61,7 @@ app.on('destroy', () => {
 const options = MiniStats.getDefaultOptions();
 
 // Click the overlay to cycle between core counters, grouped averages and graph history.
+// In the larger views, click Engine, User, CPU, GPU or VRAM to collapse or expand its sub-counters.
 // Panel width and row height can be customized independently for each mode.
 options.startSizeIndex = 2;
 

--- a/src/extras/mini-stats/graph.js
+++ b/src/extras/mini-stats/graph.js
@@ -20,6 +20,9 @@ class Graph {
         this.renderWidth = 0;
         this.parent = null;
         this.group = 0;
+        this.headerOnly = false;
+        this.headerTop = 0;
+        this.headerBottom = 0;
         this.lastNonZeroFrame = 0;
         this.statName = '';
     }
@@ -35,6 +38,7 @@ class Graph {
     // Returns a bitmask of changed average (1) and peak (2) text. The shared texture is
     // locked once by MiniStats, so all rows are updated before a single unlock/upload.
     update(ms, data) {
+        if (this.headerOnly) return 0;
         const timings = this.timer.timings;
         let total = 0;
         for (let i = 0; i < timings.length; i++) total += timings[i];

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -122,7 +122,7 @@ class MiniStats {
         this.app = app;
         this.device = app.graphicsDevice;
         this.sizes = options.sizes.map(size => ({ ...size }));
-        /** @type {Graph[]} */
+        /** @type {Graph[]} @private */
         this.graphs = [];
         this.graphRows = new Map();
         this.freeRows = [];

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -33,10 +33,16 @@ const GROUP_BACKGROUND = 0xff372b22;
 const BORDER = 0xff4e3d30;
 const TEXT = 0xfffaf5f2;
 const MUTED = 0xffc8b8ad;
-const graphColors = [0xff6db1d9, 0xfff7b884, 0xffb6d16d, 0xffdda0b8];
+const graphColors = [0xff6db1d9, 0xfff7b884, 0xffb6d16d, 0xffdda0b8, 0xff6db1d9, 0xffc8b8ad];
 
-const graphOrder = graph => (graph.label === 'Draw calls' ? 0 : graph.name === 'Frame' ? 1 : graph.group + 2);
-const compareGraphs = (a, b) => graphOrder(a) - graphOrder(b);
+const graphOrder = (graph) => {
+    if (graph.headerOnly) return 0;
+    if (graph.name === 'DrawCalls') return 1;
+    if (graph.name === 'Frame') return 2;
+    return 3;
+};
+const groupOrder = graph => (graph.group === 5 ? 0 : graph.group === 4 ? 1 : graph.group + 1);
+const compareGraphs = (a, b) => groupOrder(a) - groupOrder(b) || graphOrder(a) - graphOrder(b);
 
 /**
  * @typedef {object} MiniStatsSizeOptions
@@ -79,7 +85,9 @@ const compareGraphs = (a, b) => graphOrder(a) - graphOrder(b);
  * @property {MiniStatsProcessorOptions} cpu - CPU graph options.
  * @property {MiniStatsProcessorOptions} gpu - GPU graph options.
  * @property {MiniStatsGraphOptions[]} stats - Array of options to render additional graphs based
- * on stats collected into Application.stats.
+ * on stats collected into Application.stats. Counters sourced exclusively from AppStats.user
+ * are displayed in a collapsible User section in the detailed views. Other additional counters
+ * are grouped under Engine, including DrawCalls and Frame. VRAM keeps its own category.
  * @property {number} [gpuTimingMinSize] - Minimum size index at which to show GPU pass timing
  * graphs. Defaults to 1.
  * @property {number} [cpuTimingMinSize] - Minimum size index at which to show CPU sub-timing
@@ -97,6 +105,9 @@ const compareGraphs = (a, b) => graphOrder(a) - graphOrder(b);
  * available in all builds. GPU timing requires device support and is enabled when MiniStats
  * creates its GPU timer. Some additional counters, such as {@link AppStats#primitiveCount},
  * require a debug or profiler build. See {@link AppStats} for measurement scope and availability.
+ * In the detailed views, click a category heading to collapse or expand its sub-counters.
+ * Click elsewhere in the overlay to change size. Collapsing a category preserves its sampling
+ * and graph history.
  */
 class MiniStats {
     /**
@@ -111,12 +122,16 @@ class MiniStats {
         this.app = app;
         this.device = app.graphicsDevice;
         this.sizes = options.sizes.map(size => ({ ...size }));
+        /** @type {Graph[]} */
+        this.graphs = [];
         this.graphRows = new Map();
         this.freeRows = [];
         this.nextRowIndex = 0;
         this.gpuPassGraphs = new Map();
         this.cpuGraphs = new Map();
         this.vramGraphs = new Map();
+        /** @private */
+        this.collapsedGroups = new Set();
         this.gpuTimingMinSize = options.gpuTimingMinSize ?? 1;
         this.cpuTimingMinSize = options.cpuTimingMinSize ?? 1;
         this.vramTimingMinSize = options.vramTimingMinSize ?? 1;
@@ -124,6 +139,7 @@ class MiniStats {
         this._averageLabel = `Avg (${this.textRefreshRate / 1000}s)`;
         this.frameIndex = 0;
         this._enabled = true;
+        this._showGraphs = false;
         this._destroyed = false;
         this._geometryDirty = true;
         this._layoutDirty = true;
@@ -147,11 +163,12 @@ class MiniStats {
         div.style.cssText = 'position:fixed;background:transparent;cursor:pointer;touch-action:none;user-select:none;';
         div.setAttribute('role', 'button');
         div.tabIndex = 0;
-        div.title = 'Click to change size. Scroll or drag to view more metrics.';
+        div.title = 'Click a category to expand or collapse it. Click elsewhere to change size. Scroll or drag to view more metrics.';
         document.body.appendChild(div);
         this.div = div;
         let dragging = false;
         let pointerY = 0;
+        let startX = 0;
         let startY = 0;
         div.addEventListener('mouseenter', () => {
             this.opacity = 1;
@@ -161,11 +178,11 @@ class MiniStats {
         });
         div.addEventListener('click', (event) => {
             event.preventDefault();
-            if (this._enabled && !dragging) this.activeSizeIndex = (this.activeSizeIndex + 1) % this.sizes.length;
+            if (this._enabled && !dragging) this.handleClick(event);
             dragging = false;
         });
         div.addEventListener('keydown', (event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
+            if (this._enabled && (event.key === 'Enter' || event.key === ' ')) {
                 event.preventDefault();
                 this.activeSizeIndex = (this.activeSizeIndex + 1) % this.sizes.length;
             }
@@ -173,21 +190,26 @@ class MiniStats {
         div.addEventListener('wheel', (event) => {
             if (this._maxScroll > 0) {
                 event.preventDefault();
+                dragging = true;
                 const multiplier = event.deltaMode === 1 ? this.height : event.deltaMode === 2 ? this._panelHeight : 1;
                 this.scroll(event.deltaY * multiplier);
             }
         }, { passive: false });
         div.addEventListener('pointerdown', (event) => {
             dragging = false;
+            startX = event.clientX;
             startY = pointerY = event.clientY;
             if (event.pointerType !== 'mouse') div.setPointerCapture(event.pointerId);
         });
         div.addEventListener('pointermove', (event) => {
-            if (event.buttons && event.pointerType !== 'mouse' && this._maxScroll > 0) {
-                dragging ||= Math.abs(event.clientY - startY) > 5;
-                if (dragging) this.scroll(pointerY - event.clientY);
+            if (event.buttons) {
+                dragging ||= Math.abs(event.clientY - startY) > 5 || Math.abs(event.clientX - startX) > 5;
+                if (dragging && event.pointerType !== 'mouse' && this._maxScroll > 0) this.scroll(pointerY - event.clientY);
                 pointerY = event.clientY;
             }
+        });
+        div.addEventListener('pointercancel', () => {
+            dragging = true;
         });
 
         this.device.on('resizecanvas', this.updateDiv, this);
@@ -241,8 +263,9 @@ class MiniStats {
 
     /**
      * Returns options for three sizes: compact core counters, grouped averages, and grouped
-     * averages and peaks with graph history. Draw calls and frame time appear first, followed by
-     * ungrouped counters in their configured order, then CPU, GPU and VRAM.
+     * averages and peaks with graph history. Engine counters appear first, starting with draw
+     * calls and frame time, followed by User, CPU, GPU and VRAM. In the detailed views, Engine
+     * and User have collapsible headings, omitted when empty.
      *
      * @param {string[]} [extraStats] - Presets to include: 'gsplats' or 'gsplatsCopy'.
      * @returns {MiniStatsOptions} The default options for MiniStats.
@@ -339,6 +362,131 @@ class MiniStats {
         return this._enabled;
     }
 
+    /**
+     * Whether the Engine section is collapsed in detailed views. Defaults to false.
+     * Collapsing hides its counters without stopping sampling or discarding history. The state
+     * is preserved when changing sizes and updated when the heading is clicked.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.engineCollapsed = true;
+     */
+    set engineCollapsed(value) {
+        this.setGroupCollapsed(5, value);
+    }
+
+    /** @type {boolean} */
+    get engineCollapsed() {
+        return this.collapsedGroups.has(5);
+    }
+
+    /**
+     * Whether the User section is collapsed in detailed views. Defaults to false.
+     * Collapsing hides its counters without stopping sampling or discarding history. The state
+     * is preserved when changing sizes and updated when the heading is clicked.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.userCollapsed = true;
+     */
+    set userCollapsed(value) {
+        this.setGroupCollapsed(4, value);
+    }
+
+    /** @type {boolean} */
+    get userCollapsed() {
+        return this.collapsedGroups.has(4);
+    }
+
+    /**
+     * Whether the CPU section is collapsed in detailed views. Defaults to false.
+     * Collapsing hides its sub-counters while keeping the total visible, without stopping sampling
+     * or discarding history. The state is preserved when changing sizes and updated when the
+     * heading is clicked.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.cpuCollapsed = true;
+     */
+    set cpuCollapsed(value) {
+        this.setGroupCollapsed(1, value);
+    }
+
+    /** @type {boolean} */
+    get cpuCollapsed() {
+        return this.collapsedGroups.has(1);
+    }
+
+    /**
+     * Whether the GPU section is collapsed in detailed views. Defaults to false.
+     * Collapsing hides its sub-counters while keeping the total visible, without stopping sampling
+     * or discarding history. The state is preserved when changing sizes and updated when the
+     * heading is clicked.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.gpuCollapsed = true;
+     */
+    set gpuCollapsed(value) {
+        this.setGroupCollapsed(2, value);
+    }
+
+    /** @type {boolean} */
+    get gpuCollapsed() {
+        return this.collapsedGroups.has(2);
+    }
+
+    /**
+     * Whether the VRAM section is collapsed in detailed views. Defaults to false.
+     * Collapsing hides its sub-counters while keeping the total visible, without stopping sampling
+     * or discarding history. The state is preserved when changing sizes and updated when the
+     * heading is clicked.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.vramCollapsed = true;
+     */
+    set vramCollapsed(value) {
+        this.setGroupCollapsed(3, value);
+    }
+
+    /** @type {boolean} */
+    get vramCollapsed() {
+        return this.collapsedGroups.has(3);
+    }
+
+    /**
+     * @private
+     * @param {number} group - Section group.
+     * @param {boolean} collapsed - Whether to hide the section's counters.
+     */
+    setGroupCollapsed(group, collapsed) {
+        if (this.collapsedGroups.has(group) === collapsed) return;
+        if (collapsed) {
+            this.collapsedGroups.add(group);
+        } else {
+            this.collapsedGroups.delete(group);
+        }
+        this.updateDiv();
+    }
+
+    /**
+     * @private
+     * @param {MouseEvent} event - Click in the overlay.
+     */
+    handleClick(event) {
+        if (this._detailed) {
+            const y = this.div.getBoundingClientRect().bottom - event.clientY + 8;
+            for (const graph of this.graphs) {
+                if (y >= graph.headerBottom && y < graph.headerTop) {
+                    this.setGroupCollapsed(graph.group, !this.collapsedGroups.has(graph.group));
+                    return;
+                }
+            }
+        }
+        this.activeSizeIndex = (this.activeSizeIndex + 1) % this.sizes.length;
+    }
+
     /** @private */
     removeQueuedMesh() {
         // postrender submits the overlay for the next frame. Remove that pending reference
@@ -358,7 +506,6 @@ class MiniStats {
      * @param {MiniStatsOptions} options - Counter configuration.
      */
     initGraphs(app, device, options) {
-        this.graphs = [];
         if (options.cpu.enabled) {
             this.cpuGraph = new Graph('CPU', app, options.cpu.watermark, options.textRefreshRate, new CpuTimer(app));
             this.cpuGraph.group = 1;
@@ -369,12 +516,26 @@ class MiniStats {
             this.gpuGraph.group = 2;
             this.graphs.push(this.gpuGraph);
         }
+        const counterGroups = new Map();
         for (const entry of options.stats ?? []) {
             const timer = new StatsTimer(app, entry.stats, entry.decimalPlaces, entry.unitsName, entry.multiplier);
             const graph = new Graph(entry.name, app, entry.watermark, options.textRefreshRate, timer);
             if (entry.name === 'VRAM') {
                 graph.group = 3;
                 this.vramGraph = graph;
+            } else {
+                const user = entry.stats.length > 0 && entry.stats.every(path => path.startsWith('user.'));
+                const name = user ? 'User' : 'Engine';
+                let parent = counterGroups.get(name);
+                if (!parent) {
+                    parent = new Graph(name, app, 0, options.textRefreshRate, new StatsTimer(app, []));
+                    parent.group = user ? 4 : 5;
+                    parent.headerOnly = true;
+                    counterGroups.set(name, parent);
+                    this.graphs.push(parent);
+                }
+                graph.group = parent.group;
+                graph.parent = parent;
             }
             this.graphs.push(graph);
         }
@@ -391,7 +552,7 @@ class MiniStats {
         });
         for (const graph of this.graphs) {
             graph.texture = this.texture;
-            this.allocateRow(graph);
+            if (!graph.headerOnly) this.allocateRow(graph);
         }
     }
 
@@ -416,17 +577,17 @@ class MiniStats {
         this.render2d.targetHeight = rect.height;
         let total = this._detailed ? 31 : 8;
         let previousGroup = -1;
+        let visibleRows = 0;
         for (let i = 0; i < this.graphs.length; i++) {
-            const group = this.graphs[i].group;
-            if (this._detailed && i > 0 && group !== previousGroup) total += 5;
-            total += this.height + (i ? this.gspacing : 0);
+            const graph = this.graphs[i];
+            if ((!this._detailed && graph.headerOnly) || (this._detailed && graph.parent && this.collapsedGroups.has(graph.group))) continue;
+            const group = graph.group;
+            if (this._detailed && visibleRows > 0 && group !== previousGroup) total += 5;
+            total += this.height + (visibleRows ? this.gspacing : 0);
+            visibleRows++;
             previousGroup = group;
         }
         this._overallHeight = total;
-        this._fixedRows = 0;
-        while (this._fixedRows < this.graphs.length && (this.graphs[this._fixedRows].label === 'Draw calls' || this.graphs[this._fixedRows].name === 'Frame')) {
-            this._fixedRows++;
-        }
         this._panelWidth = Math.max(0, Math.min(this.width, rect.width - 16));
         this._panelHeight = Math.max(0, Math.min(total, rect.height - 16));
         this._maxScroll = Math.max(0, total - this._panelHeight);
@@ -501,44 +662,48 @@ class MiniStats {
             renderer.setClip(x, bottom, width, this._panelHeight - 23);
         }
         let previousGroup = -1;
+        const clipTop = rowTop;
+        renderer.setClip(x, bottom, width, Math.max(0, rowTop - bottom));
+        rowTop += this._scroll;
         for (let i = 0; i < this.graphs.length; i++) {
-            // Keep draw calls and frame time visible even when a long pass list is scrolled.
-            if (i === this._fixedRows) {
-                renderer.setClip(x, bottom, width, Math.max(0, rowTop - bottom));
-                rowTop += this._scroll;
-            }
             const graph = this.graphs[i];
             graph.quad = -1;
+            graph.headerTop = graph.headerBottom = 0;
+            if ((!this._detailed && graph.headerOnly) || (this._detailed && graph.parent && this.collapsedGroups.has(graph.group))) continue;
             if (this._detailed && i > 0 && graph.group !== previousGroup) rowTop -= 5;
             const y = rowTop - this.height;
             if (y < top && rowTop > bottom) {
                 const heading = this._detailed && graph.group > 0 && !graph.parent;
                 const color = graphColors[graph.group];
                 if (heading) {
+                    // Keep scrolled headings from receiving clicks through the column labels.
+                    graph.headerTop = Math.min(rowTop, clipTop);
+                    graph.headerBottom = Math.max(y, bottom);
                     renderer.rect(x, y, width, this.height, GROUP_BACKGROUND);
                     renderer.rect(x, y + 5, 2, this.height - 10, color);
                 }
-                if (this._showGraphs) renderer.graph(graph, x, y, width, this.height, color);
+                if (this._showGraphs && !graph.headerOnly) renderer.graph(graph, x, y, width, this.height, color);
                 const baseline = Math.round(y + (this.height - 14) / 2 + 3);
                 const units = graph.timer.unitsName || '';
-                const valueWidth = atlas.measure(graph.timingText, 1);
+                const showUnits = this._detailed && units && (!graph.parent || graph.parent.headerOnly);
+                const valueWidth = graph.headerOnly ? 0 : atlas.measure(graph.timingText, 1);
                 let valueRight = avgRight;
                 if (!this._detailed && units) {
                     const unitsWidth = atlas.measure(units);
                     atlas.render(renderer, units, right - unitsWidth, baseline, 0, MUTED);
                     valueRight -= unitsWidth + 4;
                 }
-                const valueX = Math.max(x + 10, valueRight - valueWidth);
-                atlas.render(renderer, graph.timingText, valueX, baseline, 1, TEXT, valueRight - valueX);
-                if (this._showPeak) {
+                const valueX = graph.headerOnly ? right : Math.max(x + 10, valueRight - valueWidth);
+                if (!graph.headerOnly) atlas.render(renderer, graph.timingText, valueX, baseline, 1, TEXT, valueRight - valueX);
+                if (this._showPeak && !graph.headerOnly) {
                     const peakWidth = atlas.measure(graph.maxText);
                     atlas.render(renderer, graph.maxText, right - Math.min(peakWidth, 40), baseline, 0, MUTED, 40);
                 }
                 const labelX = x + 10 + (this._detailed && graph.parent ? 5 : 0);
                 const labelStyle = heading ? 1 : 0;
                 const labelWidth = atlas.render(renderer, graph.label, labelX, baseline, labelStyle, heading ? TEXT : MUTED,
-                    valueX - labelX - 8 - (this._detailed && units && !graph.parent ? atlas.measure(units) + 4 : 0));
-                if (this._detailed && units && !graph.parent) {
+                    valueX - labelX - 8 - (showUnits ? atlas.measure(units) + 4 : 0));
+                if (showUnits) {
                     atlas.render(renderer, units, labelX + labelWidth + 4, baseline, 0, MUTED, valueX - labelX - labelWidth - 8);
                 }
             }

--- a/test/extras/mini-stats/mini-stats.test.mjs
+++ b/test/extras/mini-stats/mini-stats.test.mjs
@@ -40,25 +40,102 @@ describe('MiniStats', function () {
         jsdomTeardown();
     });
 
-    it('keeps draw calls, frame and custom counters above the CPU, GPU and VRAM groups in all modes', function () {
+    it('groups custom counters under User above the CPU, GPU and VRAM groups', function () {
         const options = MiniStats.getDefaultOptions();
-        options.stats.unshift({ name: 'Custom first', stats: ['frame.ms'] });
-        options.stats.push({ name: 'Custom second', stats: ['frame.ms'] });
+        options.stats.unshift({ name: 'Custom first', stats: ['user.first'] });
+        options.stats.push({ name: 'Update', stats: ['frame.updateTime'] });
+        options.stats.push({ name: 'FPS', stats: ['frame.fps'] });
+        options.stats.push({ name: 'Custom second', stats: ['user.second'] });
         stats = new MiniStats(app, options);
         app.stats.gpu.set('Main pass', 2);
         for (let mode = 0; mode < 3; mode++) {
             stats.activeSizeIndex = mode;
             stats.postRender();
             expect(stats.graphs.filter(graph => !graph.parent).map(graph => graph.label)).to.deep.equal([
-                'Draw calls', 'Frame', 'Custom first', 'Custom second', 'CPU', 'GPU', 'VRAM'
+                'Engine', 'User', 'CPU', 'GPU', 'VRAM'
             ]);
-            for (let i = 1; i < stats.graphs.length; i++) {
-                expect(stats.graphs[i].group).to.be.at.least(stats.graphs[i - 1].group);
-            }
+            const user = stats.graphs.find(graph => graph.headerOnly && graph.name === 'User');
+            const engine = stats.graphs.find(graph => graph.headerOnly && graph.name === 'Engine');
+            expect(stats.graphs.filter(graph => graph.parent === engine).map(graph => graph.label)).to.deep.equal(['Draw calls', 'Frame', 'Update', 'FPS']);
+            expect(stats.graphs.filter(graph => graph.parent === user).map(graph => graph.label)).to.deep.equal(['Custom first', 'Custom second']);
+            expect(user.headerTop > user.headerBottom).to.equal(mode > 0);
             expect(stats._showPeak).to.equal(mode === 2);
             expect(stats._showGraphs).to.equal(mode === 2);
             expect(stats.cpuGraphs.size > 0).to.equal(mode > 0);
         }
+    });
+
+    it('omits User when no custom counters are configured and keeps headings unindented', function () {
+        const options = MiniStats.getDefaultOptions(['gsplats']);
+        options.stats.push({ name: 'Update', stats: ['frame.updateTime'] });
+        options.stats.push({ name: 'FPS', stats: ['frame.fps'] });
+        stats = new MiniStats(app, options);
+        stats.activeSizeIndex = 2;
+        const render = spy(stats.wordAtlas, 'render');
+        stats.postRender();
+        expect(stats.graphs.some(graph => graph.headerOnly && graph.name === 'User')).to.be.false;
+        for (const label of ['Engine', 'CPU', 'GPU', 'VRAM']) {
+            expect(render.getCalls().find(call => call.args[1] === label).args[2]).to.equal(18);
+        }
+        expect(render.getCalls().some(call => ['▸', '▾'].includes(call.args[1]))).to.be.false;
+    });
+
+    it('hides all engine counters, including draw calls and frame time, when Engine is collapsed', function () {
+        const options = MiniStats.getDefaultOptions(['gsplats']);
+        options.stats.push({ name: 'FPS', stats: ['frame.fps'] });
+        options.startSizeIndex = 2;
+        stats = new MiniStats(app, options);
+        stats.postRender();
+        const engine = stats.graphs.find(graph => graph.headerOnly && graph.name === 'Engine');
+        const children = stats.graphs.filter(graph => graph.parent === engine);
+        expect(children.map(graph => graph.name)).to.deep.equal(['DrawCalls', 'Frame', 'GSplats', 'FPS']);
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom + 8 - (engine.headerTop + engine.headerBottom) / 2
+        }));
+        stats.postRender();
+        expect(children.every(graph => graph.quad === -1)).to.be.true;
+        expect(engine.headerTop).to.be.greaterThan(engine.headerBottom);
+        stats.activeSizeIndex = 0;
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        expect(stats.collapsedGroups.has(engine.group)).to.be.true;
+        expect(children.every(graph => graph.quad === -1)).to.be.true;
+    });
+
+    it('collapses user counters without aggregating unlike units or hiding them in compact mode', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.stats.push({ name: 'Custom', stats: ['user.duration'], unitsName: 'ms' });
+        app.stats.user = new Map([['duration', 16.7]]);
+        options.startSizeIndex = 2;
+        stats = new MiniStats(app, options);
+        const render = spy(stats.wordAtlas, 'render');
+        stats.postRender();
+        const user = stats.graphs.find(graph => graph.headerOnly && graph.name === 'User');
+        const custom = stats.graphs.find(graph => graph.parent === user);
+        const baseline = Math.round(user.headerBottom + (stats.height - 14) / 2 + 3);
+        expect(render.getCalls().filter(call => call.args[3] === baseline).map(call => call.args[1])).to.deep.equal(['User']);
+        expect(render.getCalls().some(call => call.args[1] === 'ms' && call.args[3] === baseline - stats.height)).to.be.true;
+        expect(stats.graphRows.has(user)).to.be.false;
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom + 8 - (user.headerTop + user.headerBottom) / 2
+        }));
+        stats.postRender();
+        expect(custom.quad).to.equal(-1);
+        const cursor = custom.cursor;
+        stats.update(500);
+        expect(custom.cursor).to.equal(cursor + 1);
+        expect(custom.timingText).to.equal('17');
+        stats.activeSizeIndex = 0;
+        render.resetHistory();
+        stats.postRender();
+        expect(render.getCalls().some(call => call.args[1] === 'User')).to.be.false;
+        expect(render.getCalls().some(call => call.args[1] === 'Custom')).to.be.true;
+        stats.activeSizeIndex = 1;
+        render.resetHistory();
+        stats.postRender();
+        expect(stats.collapsedGroups.has(user.group)).to.be.true;
+        expect(render.getCalls().some(call => call.args[1] === 'User')).to.be.true;
+        expect(render.getCalls().some(call => call.args[1] === 'Custom')).to.be.false;
     });
 
     it('does not modify caller-owned size options', function () {
@@ -67,6 +144,132 @@ describe('MiniStats', function () {
         stats = new MiniStats(app, options);
         expect(options.sizes[1].width).to.equal(192);
         expect(stats.sizes[1]).not.to.equal(options.sizes[1]);
+        expect(stats.graphs.filter(graph => graph.headerOnly).map(graph => graph.name)).to.deep.equal(['Engine']);
+    });
+
+    it('supports collapse properties before sub-counters exist and keeps them synchronized with clicks', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.stats.push({ name: 'Custom', stats: ['user.custom'] });
+        stats = new MiniStats(app, options);
+        const sections = [
+            ['engineCollapsed', 'Engine'],
+            ['userCollapsed', 'User'],
+            ['cpuCollapsed', 'CPU'],
+            ['gpuCollapsed', 'GPU'],
+            ['vramCollapsed', 'VRAM']
+        ];
+        for (const [property] of sections) {
+            expect(stats[property]).to.be.false;
+            stats[property] = true;
+        }
+        app.stats.gpu.set('Main pass', 2);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        expect(stats.graphs.filter(graph => graph.parent).every(graph => graph.quad === -1)).to.be.true;
+        for (const [property, name] of sections) {
+            expect(stats[property]).to.be.true;
+            const parent = stats.graphs.find(graph => !graph.parent && graph.name === name);
+            stats.div.dispatchEvent(new window.MouseEvent('click', {
+                clientY: stats.div.getBoundingClientRect().bottom + 8 - (parent.headerTop + parent.headerBottom) / 2
+            }));
+            stats.postRender();
+            expect(stats[property]).to.be.false;
+            expect(stats.graphs.filter(graph => graph.parent === parent).every(graph => graph.quad >= 0)).to.be.true;
+            stats[property] = true;
+            stats.postRender();
+        }
+        stats.activeSizeIndex = 0;
+        stats.activeSizeIndex = 1;
+        stats.postRender();
+        for (const [property] of sections) expect(stats[property]).to.be.true;
+    });
+
+    it('collapses each category without changing size, sampling or history', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        app.stats.gpu.set('Main pass', 2);
+        stats.postRender();
+        const click = parent => stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom + 8 - (parent.headerTop + parent.headerBottom) / 2
+        }));
+        for (const parent of [stats.cpuGraph, stats.gpuGraph, stats.vramGraph]) {
+            const children = stats.graphs.filter(graph => graph.parent === parent);
+            const height = stats.overallHeight;
+            const cursor = children[0].cursor;
+            click(parent);
+            stats.postRender();
+            expect(stats.activeSizeIndex).to.equal(2);
+            expect(stats.overallHeight).to.equal(height - children.length * stats.height);
+            expect(parent.quad).to.be.at.least(0);
+            expect(children.every(graph => graph.quad === -1)).to.be.true;
+            stats.update(stats.textRefreshRate);
+            expect(children.every(graph => graph.cursor === cursor + 1)).to.be.true;
+            expect(children.every(graph => graph.timingText !== '—')).to.be.true;
+            click(parent);
+            stats.postRender();
+            expect(stats.overallHeight).to.equal(height);
+            expect(children.every(graph => graph.quad >= 0)).to.be.true;
+        }
+    });
+
+    it('remembers independent collapsed categories through size changes', function () {
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 1;
+        stats.postRender();
+        for (const parent of [stats.cpuGraph, stats.vramGraph]) {
+            stats.div.dispatchEvent(new window.MouseEvent('click', {
+                clientY: stats.div.getBoundingClientRect().bottom + 8 - (parent.headerTop + parent.headerBottom) / 2
+            }));
+            stats.postRender();
+        }
+        for (const mode of [0, 2, 1]) {
+            stats.activeSizeIndex = mode;
+            stats.postRender();
+            expect([...stats.collapsedGroups]).to.deep.equal([1, 3]);
+            expect(stats.graphs.filter(graph => graph.parent && (graph.group === 1 || graph.group === 3)).every(graph => graph.quad === -1)).to.be.true;
+        }
+        // The column heading still cycles sizes.
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom - stats._panelHeight + 12
+        }));
+        expect(stats.activeSizeIndex).to.equal(2);
+    });
+
+    it('hit tests scrolled headings without toggling headings behind the column labels', function () {
+        canvas.getBoundingClientRect.returns({ left: 0, bottom: 240, width: 400, height: 240 });
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        stats.scroll(10000);
+        stats.render();
+        const parent = stats.vramGraph;
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom + 8 - (parent.headerTop + parent.headerBottom) / 2
+        }));
+        expect(stats.collapsedGroups.has(3)).to.be.true;
+        stats.postRender();
+        expect(stats._scroll).to.be.at.most(stats._maxScroll);
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom - stats._panelHeight + 12
+        }));
+        expect(stats.activeSizeIndex).to.equal(0);
+        expect([...stats.collapsedGroups]).to.deep.equal([3]);
+    });
+
+    it('does not interpret dragging or scrolling as a category click', function () {
+        canvas.getBoundingClientRect.returns({ left: 0, bottom: 240, width: 400, height: 240 });
+        stats = new MiniStats(app);
+        stats.activeSizeIndex = 2;
+        stats.postRender();
+        stats.div.setPointerCapture = spy();
+        stats.div.dispatchEvent(new window.MouseEvent('pointerdown', { clientY: 100 }));
+        stats.div.dispatchEvent(new window.MouseEvent('pointermove', { clientY: 120, buttons: 1 }));
+        stats.div.dispatchEvent(new window.MouseEvent('click'));
+        expect(stats.activeSizeIndex).to.equal(2);
+        stats.div.dispatchEvent(new window.WheelEvent('wheel', { deltaY: 100 }));
+        stats.div.dispatchEvent(new window.MouseEvent('click'));
+        expect(stats.activeSizeIndex).to.equal(2);
+        expect(stats.collapsedGroups.size).to.equal(0);
     });
 
     it('reuses cached geometry without uploads, text work or history writes in text modes', function () {
@@ -112,7 +315,7 @@ describe('MiniStats', function () {
         expect(upload.callCount).to.equal(10);
         expect(measure.callCount).to.equal(0);
         expect(stats.render2d.data).to.equal(data);
-        expect(stats.graphs.every(graph => graph.cursor === 10)).to.be.true;
+        expect(stats.graphs.filter(graph => !graph.headerOnly).every(graph => graph.cursor === 10)).to.be.true;
     });
 
     it('preserves existing history when new GPU passes grow the texture', function () {
@@ -120,7 +323,7 @@ describe('MiniStats', function () {
         stats.activeSizeIndex = 2;
         stats.postRender();
         stats.update(16);
-        const graph = stats.graphs[0];
+        const graph = stats.graphs.find(graph => !graph.headerOnly);
         const offset = graph.yOffset * stats.texture.width * 4;
         const before = stats.texture.lock().slice(offset, offset + 4);
         stats.texture.unlock();
@@ -154,7 +357,7 @@ describe('MiniStats', function () {
         expect(row[3]).to.equal(170);
         expect(row.subarray(4).every(value => value === 0)).to.be.true;
         stats.activeSizeIndex = 0;
-        expect(stats.graphs.every(graph => graph.parent === null)).to.be.true;
+        expect(stats.graphs.every(graph => !graph.parent || graph.parent.headerOnly)).to.be.true;
     });
 
     it('does not create sub-counters when their category is disabled', function () {
@@ -166,7 +369,7 @@ describe('MiniStats', function () {
         stats = new MiniStats(app, options);
         app.stats.gpu.set('Pass', 2);
         stats.postRender();
-        expect(stats.graphs).to.have.length(2);
+        expect(stats.graphs).to.have.length(3);
     });
 
     it('keeps the panel inside a short viewport and clamps scrolling', function () {
@@ -174,10 +377,11 @@ describe('MiniStats', function () {
         stats = new MiniStats(app);
         stats.activeSizeIndex = 2;
         stats.postRender();
-        const firstRowY = stats.render2d.data[stats.graphs[0].quad * 32 + 1];
+        const engine = stats.graphs[0];
+        expect(engine.headerTop).to.be.greaterThan(engine.headerBottom);
         stats.scroll(10000);
         stats.render();
-        expect(stats.render2d.data[stats.graphs[0].quad * 32 + 1]).to.equal(firstRowY);
+        expect(engine.headerTop).to.be.at.most(engine.headerBottom);
         expect(stats._panelWidth).to.equal(184);
         expect(stats._panelHeight).to.equal(164);
         expect(stats._scroll).to.equal(stats._maxScroll);


### PR DESCRIPTION
Make MiniStats sections independently collapsible so applications can focus on the metrics they need without losing ongoing measurements.

Expanded Sections
<img width="230" height="496" alt="Screenshot 2026-09-11 at 11 04 27" src="https://github.com/user-attachments/assets/d08fb867-62a1-41b2-9f15-5d533097b8ac" />

Collapsed Sections
<img width="234" height="174" alt="Screenshot 2026-09-11 at 11 05 43" src="https://github.com/user-attachments/assets/5a64ce74-247d-435b-b95b-1b3ee6534b08" />


**Changes:**
- Click Engine, User, CPU, GPU or VRAM headings to collapse or expand their counters in the two detailed views. Clicking elsewhere still changes size, and scrolling or dragging does not toggle sections.
- Group built-in counters, including draw calls and frame time, under Engine. Group only counters sourced from `AppStats.user` under User. Omit empty Engine and User sections.
- Keep CPU, GPU and VRAM totals visible when collapsed, preserve section state across size changes, and continue sampling and history collection. Compact mode shows individual counters without section headings.
- Scroll all sections beneath the fixed column labels, including draw calls and frame time.

**API Changes:**
Add five read/write boolean properties to `MiniStats`, all defaulting to `false` and synchronized with heading clicks:

```javascript
miniStats.engineCollapsed = true;
miniStats.userCollapsed = true;
miniStats.cpuCollapsed = true;
miniStats.gpuCollapsed = true;
miniStats.vramCollapsed = true;
```

Set a property to `false` to expand its section.

**Examples:**
Update `debug/mini-stats` instructions to describe section toggling. Its Wave counter appears under User; the built-in counters appear under Engine.

**Performance:**
Reuse existing sampling, graph history and cached geometry. Section headings do not allocate graph history rows.
