### PR TITLE
Publish the scene environment textures under their own uniforms

### DIFF
--- a/examples/src/examples/test/environment-sources.controls.jsx
+++ b/examples/src/examples/test/environment-sources.controls.jsx
@@ -22,8 +22,9 @@ const sceneEnvOptions = [
     { v: 'atlas+cubemap', t: 'atlas+cubemap' }
 ];
 
-// A material environment texture overrides the scene, priority atlas+cubemap > atlas > cubemap >
-// sphere map. 'none' uses the scene environment when useSkybox is set.
+// A material environment texture replaces the scene environment for every role, priority
+// atlas+cubemap > atlas > cubemap > sphere map. 'none' uses the scene environment when useSkybox
+// is set.
 const materialEnvOptions = [
     { v: 'none', t: 'none' },
     { v: 'atlas', t: 'atlas' },
@@ -75,7 +76,7 @@ export function Controls({ observer }) {
                 <LabelGroup text='Environment'>
                     {select('data.material.env', materialEnvOptions)}
                 </LabelGroup>
-                <LabelGroup text='Scene fills gaps (useSkybox)'>
+                <LabelGroup text='Use scene env (useSkybox)'>
                     {toggle('data.material.useSkybox')}
                 </LabelGroup>
                 <LabelGroup text='Ambient SH (overrides atlas)'>

--- a/examples/src/examples/test/environment-sources.example.mjs
+++ b/examples/src/examples/test/environment-sources.example.mjs
@@ -1,9 +1,10 @@
 // @config
 //
 // Environment lighting sources test. Engine rules: the scene atlas and cubemap combine (atlas = rough
-// reflections + ambient, cubemap = sharp mirror term); a material environment texture overrides the
-// scene, priority atlas + cubemap > atlas > cubemap > sphere map; useSkybox lets the scene fill roles
-// the material does not cover; ambient follows the atlas unless SH is set; refraction reuses reflections.
+// reflections + ambient, cubemap = sharp mirror term); a material environment texture replaces the scene
+// environment for every role, priority atlas + cubemap > atlas > cubemap > sphere map, and roles it does
+// not cover fall back to constant ambient; useSkybox allows the scene environment when the material has
+// none; ambient follows the atlas unless SH is set; refraction reuses reflections.
 // Reference sphere: scene env (wide street, an HDR). Test spheres: material env from the controls (empty room; its
 // atlas, cubemap, sphere map and SH come from one HDR and should match). The green neighbour probe draws
 // before the test spheres: green on them means a leaked texture. The overlay attributes each role.
@@ -327,16 +328,15 @@ data.on('rebuild', () => {
 // meshInstanceId right before each draw, which identifies the draw call without any renderer hooks
 const testMeshInstance = testSphere.findByName('sphere').render.meshInstances[0];
 const meshInstanceIdScope = device.scope.resolve('meshInstanceId');
-const envScopes = ['texture_envAtlas', 'texture_cubeMap', 'texture_sphereMap'].map((name) =>
-    device.scope.resolve(name)
+const envScopes = ['texture_envAtlas', 'texture_cubeMap', 'texture_sphereMap', 'scene_envAtlas', 'scene_skybox'].map(
+    (name) => device.scope.resolve(name)
 );
 let scopeAtTestDraw = 'not drawn yet';
 const originalDraw = device.draw;
 device.draw = function (...args) {
     if (meshInstanceIdScope.value === testMeshInstance.id) {
-        scopeAtTestDraw = envScopes
-            .map((scope) => `${scope.name.replace('texture_', '')}=${scope.value?.name ?? 'NONE'}`)
-            .join(', ');
+        const values = envScopes.map((scope) => `${scope.name}=${scope.value?.name ?? 'NONE'}`);
+        scopeAtTestDraw = `    ${values.slice(0, 3).join(', ')}\n    ${values.slice(3).join(', ')}`;
     }
     return originalDraw.apply(this, args);
 };
@@ -453,7 +453,8 @@ const describeSources = () => {
     const matSphere = mat.env === 'spheremap';
     const sceneAtlasOn = hasAtlas(scene.env);
     const sceneCubemapOn = hasCubemap(scene.env);
-    const sceneUsable = mat.useSkybox;
+    const materialEnv = matAtlas || matCubemap || matSphere;
+    const sceneUsable = mat.useSkybox && !materialEnv;
 
     // marks the first available candidate as the one in use
     const pick = (items) => {
@@ -485,7 +486,7 @@ const describeSources = () => {
     const ambientItems = [
         { text: 'material SH', available: mat.ambientSH, source: AMBIENTSRC_AMBIENTSH },
         { text: 'material atlas', available: matAtlas, source: AMBIENTSRC_ENVALATLAS },
-        { text: 'scene atlas', available: sceneUsable && sceneAtlasOn && !matSphere, source: AMBIENTSRC_ENVALATLAS },
+        { text: 'scene atlas', available: sceneUsable && sceneAtlasOn, source: AMBIENTSRC_ENVALATLAS },
         { text: 'constant ambientLight', available: true, source: AMBIENTSRC_CONSTANT }
     ];
     const ambient = pick(ambientItems);
@@ -512,14 +513,11 @@ const describeSources = () => {
     pick(backgroundItems);
 
     const notes = [];
-    if (materialReflections && ambient.text === 'scene atlas') {
-        notes.push('!! mixed: ambient reads texture_envAtlas, which this material does not publish');
+    if (materialEnv && !matAtlas && !mat.ambientSH) {
+        notes.push('the material environment has no atlas: ambient falls back to constant ambientLight');
     }
     if (matSphere) {
         notes.push('a sphere map is view-space: orbit the camera and its reflection follows the view');
-    }
-    if (matSphere && sceneUsable && sceneAtlasOn && !mat.ambientSH) {
-        notes.push('a sphere map disables scene atlas ambient (#7201)');
     }
     if (refraction.text === 'the reflections') {
         notes.push(
@@ -531,7 +529,7 @@ const describeSources = () => {
     if (!mat.useSkybox && !materialReflections) {
         notes.push('useSkybox off: the scene environment is ignored by this material');
     }
-    if (materialReflections && mat.useSkybox && (sceneAtlasOn || sceneCubemapOn) && ambient.text !== 'scene atlas') {
+    if (materialEnv && mat.useSkybox && (sceneAtlasOn || sceneCubemapOn)) {
         notes.push('the scene environment is present but overridden by the material');
     }
 
@@ -592,7 +590,7 @@ app.on('update', () => {
         `${notes}  ${escapeHtml(check)}\n\n` +
         `<b>COMPILED SHADER</b> (${compiles}x): ${escapeHtml(shaderInfo)}\n` +
         `  publishes: ${escapeHtml(published || '(no textures)')}\n` +
-        `  scope at test sphere draw:\n    ${escapeHtml(scopeAtTestDraw)}\n\n` +
+        `  scope at test sphere draw:\n${escapeHtml(scopeAtTestDraw)}\n\n` +
         `MISSING TEXTURE ERRORS: ${textureErrors}${lastTextureError ? `\n  ${escapeHtml(lastTextureError)}` : ''}\n` +
         'Drag to orbit the middle sphere. Green on a test sphere = a neighbour texture leaked through the scope.';
 });

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -305,6 +305,9 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.gamma = cameraShaderParams.shaderOutputGamma;
         options.litOptions.toneMap = stdMat.useTonemap ? cameraShaderParams.toneMapping : TONEMAP_NONE;
 
+        // A material environment texture replaces the scene environment for every role (reflections,
+        // ambient, refraction); the scene environment is used only when the material has none.
+        const useSceneEnv = stdMat.useSkybox && !stdMat.envAtlas && !stdMat.cubeMap && !stdMat.sphereMap;
         let usingSceneEnv = false;
 
         // source of environment reflections is as follows:
@@ -321,16 +324,16 @@ class StandardMaterialOptionsBuilder {
         } else if (stdMat.sphereMap) {
             options.litOptions.reflectionSource = REFLECTIONSRC_SPHEREMAP;
             options.litOptions.reflectionEncoding = stdMat.sphereMap.encoding;
-        } else if (stdMat.useSkybox && scene.envAtlas && scene.skybox) {
+        } else if (useSceneEnv && scene.envAtlas && scene.skybox) {
             options.litOptions.reflectionSource = REFLECTIONSRC_ENVATLASHQ;
             options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
             options.litOptions.reflectionCubemapEncoding = scene.skybox.encoding;
             usingSceneEnv = true;
-        } else if (stdMat.useSkybox && scene.envAtlas) {
+        } else if (useSceneEnv && scene.envAtlas) {
             options.litOptions.reflectionSource = REFLECTIONSRC_ENVATLAS;
             options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
             usingSceneEnv = true;
-        } else if (stdMat.useSkybox && scene.skybox) {
+        } else if (useSceneEnv && scene.skybox) {
             options.litOptions.reflectionSource = REFLECTIONSRC_CUBEMAP;
             options.litOptions.reflectionEncoding = scene.skybox.encoding;
             usingSceneEnv = true;
@@ -344,8 +347,8 @@ class StandardMaterialOptionsBuilder {
             options.litOptions.ambientSource = AMBIENTSRC_AMBIENTSH;
             options.litOptions.ambientEncoding = null;
         } else {
-            const envAtlas = stdMat.envAtlas || (stdMat.useSkybox && scene.envAtlas ? scene.envAtlas : null);
-            if (envAtlas && !stdMat.sphereMap) {
+            const envAtlas = stdMat.envAtlas || (useSceneEnv ? scene.envAtlas : null);
+            if (envAtlas) {
                 options.litOptions.ambientSource = AMBIENTSRC_ENVALATLAS;
                 options.litOptions.ambientEncoding = envAtlas.encoding;
             } else {
@@ -357,6 +360,9 @@ class StandardMaterialOptionsBuilder {
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
         options.litOptions.skyboxIntensity = usingSceneEnv;
         options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude;
+
+        // the environment chunks sample either the scene or the material textures, which use different uniforms
+        options.litOptions.useSceneEnv = usingSceneEnv;
     }
 
     _updateLightOptions(options, scene, stdMat, objDefs, sortedLights) {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -669,7 +669,6 @@ class StandardMaterial extends Material {
         this._assetReferences = {};
 
         this._activeParams = new Set();
-        this._activeLightingParams = new Set();
 
         this.shaderOptBuilder = new StandardMaterialOptionsBuilder();
 
@@ -769,24 +768,20 @@ class StandardMaterial extends Material {
     }
 
     /**
-     * Replaces the set of parameters published by one update path with the parameters published
-     * since the previous call, deleting the ones that were dropped. A parameter that the other
-     * update path currently publishes is kept: material and scene environment textures share
-     * uniform names, so it would otherwise delete a value the other path has just set.
+     * Replaces the set of parameters published by the previous update with the parameters published
+     * since, deleting the ones that were dropped.
      *
-     * @param {string} paramsName - The name of the tracked set to update.
-     * @param {Set<string>} otherParams - The set tracked by the other update path.
      * @private
      */
-    _processParameters(paramsName, otherParams) {
-        const prevParams = this[paramsName];
+    _processParameters() {
+        const prevParams = this._activeParams;
         prevParams.forEach((param) => {
-            if (!_params.has(param) && !otherParams.has(param)) {
+            if (!_params.has(param)) {
                 delete this.parameters[param];
             }
         });
 
-        this[paramsName] = _params;
+        this._activeParams = _params;
         _params = prevParams;
         _params.clear();
     }
@@ -962,36 +957,16 @@ class StandardMaterial extends Material {
         this._setParameter('material_reflectivity', this.reflectivity);
 
         // remove unused params
-        this._processParameters('_activeParams', this._activeLightingParams);
+        this._processParameters();
 
         // Clear variants dirtied by compatibility processing above.
         super.updateUniforms(device, scene);
-    }
-
-    updateEnvUniforms(device, scene) {
-        const hasLocalEnvOverride = this.envAtlas || this.cubeMap || this.sphereMap;
-
-        if (!hasLocalEnvOverride && this.useSkybox) {
-            if (scene.envAtlas && scene.skybox) {
-                this._setParameter('texture_envAtlas', scene.envAtlas);
-                this._setParameter('texture_cubeMap', scene.skybox);
-            } else if (scene.envAtlas) {
-                this._setParameter('texture_envAtlas', scene.envAtlas);
-            } else if (scene.skybox) {
-                this._setParameter('texture_cubeMap', scene.skybox);
-            }
-        }
-
-        this._processParameters('_activeLightingParams', this._activeParams);
     }
 
     /** @ignore */
     getShaderVariant(params) {
 
         const { device, scene, pass, objDefs, sortedLights, cameraShaderParams } = params;
-
-        // update prefiltered lighting data
-        this.updateEnvUniforms(device, scene);
 
         // Minimal options for Depth, Shadow and Prepass passes
         const shaderPassInfo = ShaderPass.get(device).getByIndex(pass);

--- a/src/scene/renderer/forward-renderer.js
+++ b/src/scene/renderer/forward-renderer.js
@@ -104,6 +104,8 @@ class ForwardRenderer extends Renderer {
         this.ambientId = scope.resolve('light_globalAmbient');
         this.skyboxIntensityId = scope.resolve('skyboxIntensity');
         this.cubeMapRotationMatrixId = scope.resolve('cubeMapRotationMatrix');
+        this.sceneEnvAtlasId = scope.resolve('scene_envAtlas');
+        this.sceneSkyboxId = scope.resolve('scene_skybox');
         this.pcssDiskSamplesId = scope.resolve('pcssDiskSamples[0]');
         this.pcssSphereSamplesId = scope.resolve('pcssSphereSamples[0]');
         this.lightColorId = [];
@@ -182,6 +184,10 @@ class ForwardRenderer extends Renderer {
 
         this.skyboxIntensityId.setValue(scene.physicalUnits ? scene.skyboxLuminance : scene.skyboxIntensity);
         this.cubeMapRotationMatrixId.setValue(scene._skyboxRotationMat3.data);
+
+        // the scene environment textures, sampled by materials without an environment of their own
+        this.sceneEnvAtlasId.setValue(scene.envAtlas);
+        this.sceneSkyboxId.setValue(scene.skybox);
     }
 
     _resolveLight(scope, i) {

--- a/src/scene/shader-lib/glsl/chunks/chunk-validation.js
+++ b/src/scene/shader-lib/glsl/chunks/chunk-validation.js
@@ -37,9 +37,9 @@ const chunkVersions = {
     reflDirPS: '1.62',
     reflDirAnisoPS: '1.62',
     reflectionCCPS: '1.62',
-    reflectionCubePS: '2.6',
-    reflectionEnvPS: '2.6',
-    reflectionEnvHQPS: '2.6',
+    reflectionCubePS: '2.23',
+    reflectionEnvPS: '2.23',
+    reflectionEnvHQPS: '2.23',
     reflectionSpherePS: '2.6',
     reflectionSheenPS: '1.62',
     shadowCommonPS: '1.62',
@@ -60,7 +60,8 @@ const chunkVersions = {
     refractionDynamicPS: '1.70',
 
     // text
-    msdfPS: '2.20'
+    msdfPS: '2.20',
+    ambientPS: '2.23'
 };
 
 // removed

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/ambient.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/ambient.js
@@ -9,7 +9,7 @@ export default /* glsl */`
 
     #ifndef ENV_ATLAS
     #define ENV_ATLAS
-        uniform sampler2D texture_envAtlas;
+        uniform sampler2D {LIT_ENV_ATLAS};
     #endif
 #endif
 
@@ -37,7 +37,7 @@ void addAmbient(vec3 worldNormal) {
         vec3 dir = normalize(cubeMapRotate(worldNormal) * vec3(-1.0, 1.0, 1.0));
         vec2 uv = mapUv(toSphericalUv(dir), vec4(128.0, 256.0 + 128.0, 64.0, 32.0) / atlasSize);
 
-        vec4 raw = texture2D(texture_envAtlas, uv);
+        vec4 raw = texture2D({LIT_ENV_ATLAS}, uv);
         vec3 linear = {ambientDecode}(raw);
         dDiffuseLight += processEnvironment(linear);
 

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionCube.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionCube.js
@@ -1,11 +1,11 @@
 export default /* glsl */`
-uniform samplerCube texture_cubeMap;
+uniform samplerCube {LIT_ENV_CUBEMAP};
 uniform float material_reflectivity;
 
 vec3 calcReflection(vec3 reflDir, float gloss) {
     vec3 lookupVec = cubeMapProject(reflDir);
     lookupVec.x *= -1.0;
-    return {reflectionDecode}(textureCube(texture_cubeMap, lookupVec));
+    return {reflectionDecode}(textureCube({LIT_ENV_CUBEMAP}, lookupVec));
 }
 
 void addReflection(vec3 reflDir, float gloss) {   

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnv.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnv.js
@@ -1,7 +1,7 @@
 export default /* glsl */`
 #ifndef ENV_ATLAS
 #define ENV_ATLAS
-    uniform sampler2D texture_envAtlas;
+    uniform sampler2D {LIT_ENV_ATLAS};
 #endif
 uniform float material_reflectivity;
 
@@ -45,10 +45,10 @@ vec3 calcReflection(vec3 reflDir, float gloss) {
         weight = 0.0;
     }
 
-    vec3 linearA = {reflectionDecode}(texture2D(texture_envAtlas, uv0));
-    vec3 linearB = {reflectionDecode}(texture2D(texture_envAtlas, uv1));
+    vec3 linearA = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, uv0));
+    vec3 linearB = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, uv1));
     vec3 linear0 = mix(linearA, linearB, weight);
-    vec3 linear1 = {reflectionDecode}(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel + 1.0)));
+    vec3 linear1 = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, mapRoughnessUv(uv, ilevel + 1.0)));
 
     return processEnvironment(mix(linear0, linear1, level - ilevel));
 }

--- a/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnvHQ.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnvHQ.js
@@ -1,9 +1,9 @@
 export default /* glsl */`
 #ifndef ENV_ATLAS
     #define ENV_ATLAS
-    uniform sampler2D texture_envAtlas;
+    uniform sampler2D {LIT_ENV_ATLAS};
 #endif
-uniform samplerCube texture_cubeMap;
+uniform samplerCube {LIT_ENV_CUBEMAP};
 uniform float material_reflectivity;
 
 vec3 calcReflection(vec3 reflDir, float gloss) {
@@ -15,9 +15,9 @@ vec3 calcReflection(vec3 reflDir, float gloss) {
     float ilevel = floor(level);
     float flevel = level - ilevel;
 
-    vec3 sharp = {reflectionCubemapDecode}(textureCube(texture_cubeMap, dir));
-    vec3 roughA = {reflectionDecode}(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel)));
-    vec3 roughB = {reflectionDecode}(texture2D(texture_envAtlas, mapRoughnessUv(uv, ilevel + 1.0)));
+    vec3 sharp = {reflectionCubemapDecode}(textureCube({LIT_ENV_CUBEMAP}, dir));
+    vec3 roughA = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, mapRoughnessUv(uv, ilevel)));
+    vec3 roughB = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, mapRoughnessUv(uv, ilevel + 1.0)));
 
     return processEnvironment(mix(sharp, mix(roughA, roughB, flevel), min(level, 1.0)));
 }

--- a/src/scene/shader-lib/programs/lit-shader-options.js
+++ b/src/scene/shader-lib/programs/lit-shader-options.js
@@ -245,6 +245,13 @@ class LitShaderOptions {
      */
     useCubeMapRotation = false;
 
+    /**
+     * If the environment chunks sample the scene environment, published by the renderer as
+     * `scene_envAtlas` and `scene_skybox`, instead of the textures owned by the material
+     * (`texture_envAtlas`, `texture_cubeMap`).
+     */
+    useSceneEnv = false;
+
     lightMapWithoutAmbient = false;
 
     lights = [];

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -532,6 +532,10 @@ class LitShader {
         this.fDefineSet(true, '{reflectionCubemapDecode}', ChunkUtils.decodeFunc(options.reflectionCubemapEncoding));
         this.fDefineSet(true, '{ambientDecode}', ChunkUtils.decodeFunc(options.ambientEncoding));
 
+        // environment textures are owned by the scene or by the material, under different uniform names
+        this.fDefineSet(true, '{LIT_ENV_ATLAS}', options.useSceneEnv ? 'scene_envAtlas' : 'texture_envAtlas');
+        this.fDefineSet(true, '{LIT_ENV_CUBEMAP}', options.useSceneEnv ? 'scene_skybox' : 'texture_cubeMap');
+
         // lighting defines
         this._setupLightingDefines(hasAreaLights, options.clusteredLightingEnabled);
     }

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/ambient.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/ambient.js
@@ -9,8 +9,8 @@ export default /* wgsl */`
 
     #ifndef ENV_ATLAS
         #define ENV_ATLAS
-        var texture_envAtlas: texture_2d<f32>;
-        var texture_envAtlasSampler: sampler;
+        var {LIT_ENV_ATLAS}: texture_2d<f32>;
+        var {LIT_ENV_ATLAS}Sampler: sampler;
     #endif
 #endif
 
@@ -38,7 +38,7 @@ fn addAmbient(worldNormal: vec3f) {
         let dir: vec3f = normalize(cubeMapRotate(worldNormal) * vec3f(-1.0, 1.0, 1.0));
         let uv: vec2f = mapUv(toSphericalUv(dir), vec4f(128.0, 256.0 + 128.0, 64.0, 32.0) / atlasSize);
 
-        let raw: vec4f = textureSample(texture_envAtlas, texture_envAtlasSampler, uv);
+        let raw: vec4f = textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, uv);
         let linear: vec3f = {ambientDecode}(raw);
         dDiffuseLight += processEnvironment(linear);
 

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionCube.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionCube.js
@@ -1,12 +1,12 @@
 export default /* wgsl */`
-var texture_cubeMap: texture_cube<f32>;
-var texture_cubeMapSampler: sampler;
+var {LIT_ENV_CUBEMAP}: texture_cube<f32>;
+var {LIT_ENV_CUBEMAP}Sampler: sampler;
 uniform material_reflectivity: f32;
 
 fn calcReflection(reflDir: vec3f, gloss: f32) -> vec3f {
     var lookupVec: vec3f = cubeMapProject(reflDir);
     lookupVec.x = lookupVec.x * -1.0;
-    return {reflectionDecode}(textureSample(texture_cubeMap, texture_cubeMapSampler, lookupVec));
+    return {reflectionDecode}(textureSample({LIT_ENV_CUBEMAP}, {LIT_ENV_CUBEMAP}Sampler, lookupVec));
 }
 
 fn addReflection(reflDir: vec3f, gloss: f32) {

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnv.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnv.js
@@ -1,8 +1,8 @@
 export default /* wgsl */`
 #ifndef ENV_ATLAS
 #define ENV_ATLAS
-    var texture_envAtlas: texture_2d<f32>;
-    var texture_envAtlasSampler: sampler;
+    var {LIT_ENV_ATLAS}: texture_2d<f32>;
+    var {LIT_ENV_ATLAS}Sampler: sampler;
 #endif
 uniform material_reflectivity: f32;
 
@@ -48,10 +48,10 @@ fn calcReflection(reflDir: vec3f, gloss: f32) -> vec3f {
         weight = 0.0;
     }
 
-    let linearA: vec3f = {reflectionDecode}(textureSample(texture_envAtlas, texture_envAtlasSampler, uv0));
-    let linearB: vec3f = {reflectionDecode}(textureSample(texture_envAtlas, texture_envAtlasSampler, uv1));
+    let linearA: vec3f = {reflectionDecode}(textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, uv0));
+    let linearB: vec3f = {reflectionDecode}(textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, uv1));
     let linear0: vec3f = mix(linearA, linearB, weight);
-    let linear1: vec3f = {reflectionDecode}(textureSample(texture_envAtlas, texture_envAtlasSampler, mapRoughnessUv(uv, ilevel + 1.0)));
+    let linear1: vec3f = {reflectionDecode}(textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, mapRoughnessUv(uv, ilevel + 1.0)));
 
     return processEnvironment(mix(linear0, linear1, level - ilevel));
 }

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnvHQ.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnvHQ.js
@@ -1,12 +1,12 @@
 export default /* wgsl */`
 #ifndef ENV_ATLAS
     #define ENV_ATLAS
-    var texture_envAtlas: texture_2d<f32>;
-    var texture_envAtlasSampler: sampler;
+    var {LIT_ENV_ATLAS}: texture_2d<f32>;
+    var {LIT_ENV_ATLAS}Sampler: sampler;
 #endif
 
-var texture_cubeMap: texture_cube<f32>;
-var texture_cubeMapSampler: sampler;
+var {LIT_ENV_CUBEMAP}: texture_cube<f32>;
+var {LIT_ENV_CUBEMAP}Sampler: sampler;
 uniform material_reflectivity: f32;
 
 fn calcReflection(reflDir: vec3f, gloss: f32) -> vec3f {
@@ -18,9 +18,9 @@ fn calcReflection(reflDir: vec3f, gloss: f32) -> vec3f {
     let ilevel: f32 = floor(level);
     let flevel: f32 = level - ilevel;
 
-    let sharp: vec3f = {reflectionCubemapDecode}(textureSample(texture_cubeMap, texture_cubeMapSampler, dir));
-    let roughA: vec3f = {reflectionDecode}(textureSample(texture_envAtlas, texture_envAtlasSampler, mapRoughnessUv(uv, ilevel)));
-    let roughB: vec3f = {reflectionDecode}(textureSample(texture_envAtlas, texture_envAtlasSampler, mapRoughnessUv(uv, ilevel + 1.0)));
+    let sharp: vec3f = {reflectionCubemapDecode}(textureSample({LIT_ENV_CUBEMAP}, {LIT_ENV_CUBEMAP}Sampler, dir));
+    let roughA: vec3f = {reflectionDecode}(textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, mapRoughnessUv(uv, ilevel)));
+    let roughB: vec3f = {reflectionDecode}(textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, mapRoughnessUv(uv, ilevel + 1.0)));
 
     return processEnvironment(mix(sharp, mix(roughA, roughB, flevel), min(level, 1.0)));
 }

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -3,7 +3,11 @@ import { expect } from 'chai';
 import { Color } from '../../../src/core/math/color.js';
 import { Vec2 } from '../../../src/core/math/vec2.js';
 import { BoundingBox } from '../../../src/core/shape/bounding-box.js';
-import { CUBEPROJ_NONE, DETAILMODE_MUL, DITHER_NONE, FRESNEL_SCHLICK, SPECOCC_AO } from '../../../src/scene/constants.js';
+import { CameraShaderParams } from '../../../src/scene/camera-shader-params.js';
+import {
+    AMBIENTSRC_CONSTANT, AMBIENTSRC_ENVALATLAS, CUBEPROJ_NONE, DETAILMODE_MUL, DITHER_NONE, FRESNEL_SCHLICK,
+    REFLECTIONSRC_CUBEMAP, REFLECTIONSRC_ENVATLASHQ, REFLECTIONSRC_NONE, SHADER_FORWARD, SPECOCC_AO
+} from '../../../src/scene/constants.js';
 import { Material } from '../../../src/scene/materials/material.js';
 import { StandardMaterialOptionsBuilder } from '../../../src/scene/materials/standard-material-options-builder.js';
 import { StandardMaterialOptions } from '../../../src/scene/materials/standard-material-options.js';
@@ -755,64 +759,81 @@ describe('StandardMaterial', function () {
 
     });
 
-    describe('#updateEnvUniforms()', function () {
+    describe('environment textures', function () {
         const envTexture = name => ({ name, encoding: 'rgbm' });
-        const scene = { envAtlas: envTexture('sceneAtlas'), skybox: envTexture('sceneSkybox') };
+        const scene = {
+            envAtlas: envTexture('sceneAtlas'),
+            skybox: envTexture('sceneSkybox'),
+            _skyboxRotationShaderInclude: false
+        };
+        const cameraShaderParams = new CameraShaderParams();
+        const noLights = [[], [], []];
 
-        // mirrors the renderer: the version-gated uniform update, then the shader variant request
-        const prepare = (material) => {
-            material.updateUniforms(null, scene);
-            material.updateEnvUniforms(null, scene);
+        const resolve = (material) => {
+            const options = new StandardMaterialOptions();
+            material.shaderOptBuilder.updateRef(options, scene, cameraShaderParams, material, 0, SHADER_FORWARD, noLights);
+            return options.litOptions;
         };
 
-        it('publishes the scene environment textures when the material has none', function () {
+        it('publishes only the material environment textures', function () {
             const material = new StandardMaterial();
             material.update();
-            prepare(material);
-
-            expect(material.getParameter('texture_envAtlas').data).to.equal(scene.envAtlas);
-            expect(material.getParameter('texture_cubeMap').data).to.equal(scene.skybox);
-        });
-
-        it('keeps a material environment texture published when it replaces the scene one', function () {
-            const material = new StandardMaterial();
-            material.update();
-            prepare(material);
-
-            const atlas = envTexture('materialAtlas');
-            material.envAtlas = atlas;
-            material.update();
-            prepare(material);
-
-            expect(material.getParameter('texture_envAtlas').data).to.equal(atlas);
-            expect(material.getParameter('texture_cubeMap')).to.be.undefined;
-        });
-
-        it('publishes the scene environment textures again when the material texture is removed', function () {
-            const material = new StandardMaterial();
-            material.envAtlas = envTexture('materialAtlas');
-            material.update();
-            prepare(material);
-
-            material.envAtlas = null;
-            material.update();
-            prepare(material);
-
-            expect(material.getParameter('texture_envAtlas').data).to.equal(scene.envAtlas);
-            expect(material.getParameter('texture_cubeMap').data).to.equal(scene.skybox);
-        });
-
-        it('drops the scene environment textures when useSkybox is disabled', function () {
-            const material = new StandardMaterial();
-            material.update();
-            prepare(material);
-
-            material.useSkybox = false;
-            material.update();
-            prepare(material);
-
+            material.updateUniforms(null, scene);
             expect(material.getParameter('texture_envAtlas')).to.be.undefined;
             expect(material.getParameter('texture_cubeMap')).to.be.undefined;
+
+            const atlas = envTexture('materialAtlas');
+            const cubemap = envTexture('materialCubemap');
+            material.envAtlas = atlas;
+            material.cubeMap = cubemap;
+            material.update();
+            material.updateUniforms(null, scene);
+            expect(material.getParameter('texture_envAtlas').data).to.equal(atlas);
+            expect(material.getParameter('texture_cubeMap').data).to.equal(cubemap);
+
+            material.envAtlas = null;
+            material.cubeMap = null;
+            material.update();
+            material.updateUniforms(null, scene);
+            expect(material.getParameter('texture_envAtlas')).to.be.undefined;
+            expect(material.getParameter('texture_cubeMap')).to.be.undefined;
+        });
+
+        it('uses the scene environment only when the material has none', function () {
+            const material = new StandardMaterial();
+            let lit = resolve(material);
+            expect(lit.useSceneEnv).to.equal(true);
+            expect(lit.reflectionSource).to.equal(REFLECTIONSRC_ENVATLASHQ);
+            expect(lit.ambientSource).to.equal(AMBIENTSRC_ENVALATLAS);
+
+            material.useSkybox = false;
+            lit = resolve(material);
+            expect(lit.useSceneEnv).to.equal(false);
+            expect(lit.reflectionSource).to.equal(REFLECTIONSRC_NONE);
+            expect(lit.ambientSource).to.equal(AMBIENTSRC_CONSTANT);
+        });
+
+        it('switches every role to the material when it has an environment texture', function () {
+            const material = new StandardMaterial();
+            material.cubeMap = envTexture('materialCubemap');
+            let lit = resolve(material);
+            expect(lit.useSceneEnv).to.equal(false);
+            expect(lit.reflectionSource).to.equal(REFLECTIONSRC_CUBEMAP);
+            expect(lit.ambientSource).to.equal(AMBIENTSRC_CONSTANT);
+            expect(lit.skyboxIntensity).to.equal(false);
+
+            material.envAtlas = envTexture('materialAtlas');
+            lit = resolve(material);
+            expect(lit.reflectionSource).to.equal(REFLECTIONSRC_ENVATLASHQ);
+            expect(lit.ambientSource).to.equal(AMBIENTSRC_ENVALATLAS);
+        });
+
+        it('includes the environment ownership in the shader key', function () {
+            const options = new StandardMaterialOptions();
+            const materialKey = standard.generateKey(options);
+
+            options.litOptions.useSceneEnv = true;
+            expect(standard.generateKey(options)).to.not.equal(materialKey);
         });
     });
 


### PR DESCRIPTION
## Description
The scene's environment atlas and skybox reached materials through `StandardMaterial.updateEnvUniforms`, which wrote them into the material's own `parameters` at shader-variant time, under the same `texture_envAtlas` / `texture_cubeMap` names the material uses for its own environment textures. Consequences: every StandardMaterial carried scene state, the texture a shader actually sampled could depend on whatever the previous draw call left in the scope (the `texture_envAtlas ... was not set` class of errors, #5364), a second parameter tracker was needed to prune the scene entries, and a scene skybox swap forced a global variant rebuild just to refresh a texture reference. It also blocks material-owned bind groups, which must not be mutated by scene state.

This PR gives the two sides separate uniforms:

- **Scene**: `ForwardRenderer.dispatchGlobalLights` publishes `scene.envAtlas` and `scene.skybox` as `scene_envAtlas` / `scene_skybox` once per camera, next to `skyboxIntensity` / `cubeMapRotationMatrix`. They are unmatched by any material format, so they bind through the mesh bind group like the other scene textures.
- **Material**: `texture_envAtlas` / `texture_cubeMap` / `texture_sphereMap` are published only by `updateUniforms` for the material's own textures. `updateEnvUniforms` and `_activeLightingParams` are removed; `getShaderVariant` no longer mutates the material.
- **Shader**: `ambientPS`, `reflectionEnvPS`, `reflectionEnvHQPS` and `reflectionCubePS` (GLSL and WGSL) sample through `{LIT_ENV_ATLAS}` / `{LIT_ENV_CUBEMAP}`, resolved per variant from the new `litOptions.useSceneEnv` (part of the shader key). Their chunk API version is bumped to 2.23.
- **Resolution is all-or-nothing**: a material environment texture replaces the scene environment for every role (reflections, ambient, refraction); a role the material cannot cover falls back to the constant ambient light. This removes the `#7201` sphere-map special case, which was the same rule applied to one texture type.

The environment sources test example (`test/environment-sources`) is updated to mirror the new rules, and its neighbour probe can no longer leak a texture into a scene-lit material.

## Public API changes
- `LitShaderOptions#useSceneEnv` (new, set by `StandardMaterialOptionsBuilder`).
- Custom overrides of `ambientPS`, `reflectionEnvPS`, `reflectionEnvHQPS` or `reflectionCubePS` that hard-code `texture_envAtlas` / `texture_cubeMap` keep working for materials with their own environment textures but receive no texture on scene-lit materials; they need to switch to the `{LIT_ENV_ATLAS}` / `{LIT_ENV_CUBEMAP}` tokens (chunk API 2.23, reported by the chunk validation). Documented in the shader chunk migrations page (developer-site PR to follow).
- Behaviour: a material with only a `cubeMap` (or `sphereMap`) now uses constant ambient instead of the scene atlas. That combination has been binding no atlas since #4403, so it rendered with whatever the previous draw call left in the scope; materials that need image-based ambient of their own should set an `envAtlas`.

## Testing
- New unit tests: materials publish only their own environment textures; the scene environment is used only when the material has none; a material cubemap switches every role to the material (constant ambient, no scene intensity); `useSceneEnv` is part of the shader key. The obsolete `updateEnvUniforms` tests are removed.
- `npm test` under Node 22: 2838 passing.
- Verified in the browser on WebGL2 and WebGPU with the test example: scene env, material atlas / cubemap / sphere map rows, the neighbour probe, and the compiled-shader cross-check agree in every state; no missing-texture errors.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] This PR focuses on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
