### PR TITLE
Load audio assets regardless of the URL's file extension

### DIFF
--- a/src/framework/parsers/audio.js
+++ b/src/framework/parsers/audio.js
@@ -1,21 +1,10 @@
-import { path } from '../../core/path.js';
 import { Http } from '../../platform/net/http.js';
 import { Sound } from '../../platform/sound/sound.js';
 
-const supportedExtensions = [
-    '.ogg',
-    '.mp3',
-    '.wav',
-    '.mp4a',
-    '.m4a',
-    '.mp4',
-    '.aac',
-    '.opus'
-];
-
 /**
  * Parser for audio resources. Fetches the audio data and decodes it into a {@link Sound} using
- * the Web Audio context of the sound manager.
+ * the Web Audio context of the sound manager. The format is determined by the browser from the
+ * fetched bytes, so the URL needs no recognizable file extension.
  *
  * @ignore
  */
@@ -42,11 +31,6 @@ class AudioParser {
             callback(msg);
         };
 
-        if (!this._isSupported(original)) {
-            error(`Audio format for ${original} not supported`);
-            return;
-        }
-
         // guard a missing sound manager too (the handler only asserts it in debug builds)
         const manager = this.handler.manager;
         if (!manager?.context) {
@@ -62,12 +46,6 @@ class AudioParser {
 
             manager.context.decodeAudioData(response, success, error);
         }, asset);
-    }
-
-    _isSupported(url) {
-        const ext = path.getExtension(url).toLowerCase();
-
-        return supportedExtensions.indexOf(ext) > -1;
     }
 }
 

--- a/test/framework/handlers/audio-handler.test.mjs
+++ b/test/framework/handlers/audio-handler.test.mjs
@@ -38,28 +38,32 @@ describe('AudioHandler', function () {
         expect(result.buffer).to.equal(fakeAudioBuffer);
     });
 
-    it('rejects an unsupported format without fetching, with the exact error message', function () {
+    it('loads a url without a file extension (the format is decided by the decoder, not the url)', function () {
         const handler = createHandler();
-        const warnStub = stub(console, 'warn');
-        const getStub = stub(http, 'get');
-
-        let err;
-        handler.load({ load: 'x.xyz', original: 'x.xyz' }, (e) => {
-            err = e;
+        let requestOptions;
+        stub(http, 'get').callsFake((url, options, callback) => {
+            requestOptions = options;
+            callback(null, new ArrayBuffer(8));
         });
-        expect(err).to.equal('Error loading audio url: x.xyz: Audio format for x.xyz not supported');
-        expect(getStub.called).to.be.false;
-        expect(warnStub.called).to.be.true;
+
+        let result;
+        handler.load({ load: 'sounds/mysound', original: 'sounds/mysound' }, (err, res) => {
+            expect(err).to.equal(null);
+            result = res;
+        });
+        expect(requestOptions.responseType).to.equal(Http.ResponseType.ARRAY_BUFFER);
+        expect(result).to.be.an.instanceof(Sound);
+        expect(result.buffer).to.equal(fakeAudioBuffer);
     });
 
-    it('accepts supported formats regardless of extension case', function () {
+    it('loads a format the browser can decode even if its extension is not a well-known one', function () {
         const handler = createHandler();
         stub(http, 'get').callsFake((url, options, callback) => {
             callback(null, new ArrayBuffer(8));
         });
 
         let result;
-        handler.load({ load: 'SOUND.MP3', original: 'SOUND.MP3' }, (err, res) => {
+        handler.load({ load: 'x.webm', original: 'x.webm' }, (err, res) => {
             expect(err).to.equal(null);
             result = res;
         });


### PR DESCRIPTION
Fixes #5309

The audio parser rejected any URL whose extension was not in a hard-coded list of eight, before fetching anything. The list dates from 2016, when it fed `new Audio().canPlayType()` for the `<audio>` element fallback. That fallback is long gone and `decodeAudioData` identifies the format from the bytes, so the check only produced false negatives: extension-less URLs (obfuscated or content-negotiated, as in the issue), and formats the browser can decode but the list omitted such as `.webm`, `.flac` or `.oga`.

Since #9006 the parser always fetches as an ArrayBuffer, so the extension check was the sole remaining blocker.

**Changes:**
- Remove the extension allowlist from `AudioParser`. The decoder decides what is supported, matching the image and GLB container parsers, which also defer to the browser.
- An unsupported format is now reported after the fetch as `Error loading audio url: <url>: <decode error>` instead of being rejected up front with `Audio format for <url> not supported`.
- Tests: replace the two extension-pinning cases with an extension-less URL case and an unlisted-extension (`.webm`) case.

No public API changes.