### PR TITLE
Add tracked resource counts to MiniStats

### DIFF
--- a/examples/src/examples/debug/mini-stats.controls.jsx
+++ b/examples/src/examples/debug/mini-stats.controls.jsx
@@ -1,0 +1,51 @@
+import { BindingTwoWay, BooleanInput, LabelGroup, Panel } from '@playcanvas/pcui/react';
+
+/**
+ * @import { Observer } from '@playcanvas/observer'
+ * @import { ReactElement } from 'react'
+ */
+
+/**
+ * @param {{ observer: Observer }} props - The control panel props.
+ * @returns {ReactElement} The control panel.
+ */
+export function Controls({ observer }) {
+    return (
+        <>
+            <Panel headerText='Settings'>
+                {[
+                    ['enabled', 'Enable MiniStats'],
+                    ['resourcesEnabled', 'Show resources']
+                ].map(([property, label]) => (
+                    <LabelGroup key={property} text={label}>
+                        <BooleanInput
+                            type='toggle'
+                            binding={new BindingTwoWay()}
+                            link={{ observer, path: `settings.${property}` }}
+                            value={observer.get(`settings.${property}`)}
+                        />
+                    </LabelGroup>
+                ))}
+            </Panel>
+            <Panel headerText='Collapsed sections'>
+                {[
+                    ['engineCollapsed', 'Engine'],
+                    ['userCollapsed', 'User'],
+                    ['cpuCollapsed', 'CPU'],
+                    ['gpuCollapsed', 'GPU'],
+                    ['vramCollapsed', 'VRAM'],
+                    ['resourcesCollapsed', 'Resources']
+                ].map(([property, label]) => (
+                    <LabelGroup key={property} text={label}>
+                        <BooleanInput
+                            type='toggle'
+                            binding={new BindingTwoWay()}
+                            link={{ observer, path: `settings.${property}` }}
+                            value={observer.get(`settings.${property}`)}
+                        />
+                    </LabelGroup>
+                ))}
+            </Panel>
+        </>
+    );
+}

--- a/examples/src/examples/debug/mini-stats.example.mjs
+++ b/examples/src/examples/debug/mini-stats.example.mjs
@@ -25,7 +25,7 @@ import {
     createGraphicsDevice
 } from 'playcanvas';
 
-import { deviceType } from 'examples/context';
+import { data, deviceType } from 'examples/context';
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('application-canvas'));
 window.focus();
@@ -61,7 +61,7 @@ app.on('destroy', () => {
 const options = MiniStats.getDefaultOptions();
 
 // Click the overlay to cycle between core counters, grouped averages and graph history.
-// In the larger views, click Engine, User, CPU, GPU or VRAM to collapse or expand its sub-counters.
+// In the larger views, click Engine, User, CPU, GPU, VRAM or Resources to collapse or expand its sub-counters.
 // Panel width and row height can be customized independently for each mode.
 options.startSizeIndex = 2;
 
@@ -148,6 +148,35 @@ options.stats = [
 // Create mini-stats system
 app.stats.user.set('wave', 10);
 const miniStats = new MiniStats(app, options);
+// Mirror the public boolean APIs in the controls panel.
+const toggleProperties = /** @type {const} */ ([
+    'enabled',
+    'resourcesEnabled',
+    'engineCollapsed',
+    'userCollapsed',
+    'cpuCollapsed',
+    'gpuCollapsed',
+    'vramCollapsed',
+    'resourcesCollapsed'
+]);
+data.set('settings', Object.fromEntries(toggleProperties.map((property) => [property, miniStats[property]])));
+const settingsEvents = toggleProperties.map((property) =>
+    data.on(`settings.${property}:set`, (value) => {
+        miniStats[property] = value;
+    })
+);
+
+// Clicking the overlay headings also changes these properties.
+const syncControls = () => {
+    for (const property of toggleProperties) {
+        data.set(`settings.${property}`, miniStats[property]);
+    }
+};
+const statsDiv = document.getElementById('mini-stats');
+statsDiv.addEventListener('click', syncControls);
+// The examples browser's toolbar can independently show or hide the overlay.
+const visibilityObserver = new MutationObserver(syncControls);
+visibilityObserver.observe(statsDiv, { attributes: true, attributeFilter: ['style'] });
 
 const step = 10;
 const max = 2000;
@@ -385,6 +414,9 @@ app.on('update', (dt) => {
 });
 
 app.on('destroy', () => {
+    for (const event of settingsEvents) event.unbind();
+    statsDiv.removeEventListener('click', syncControls);
+    visibilityObserver.disconnect();
     device.off('resizecanvas', fitScene);
     for (const item of entities) item.render.material.destroy();
     for (const buffer of vertexBuffers) buffer.destroy();

--- a/src/extras/mini-stats/graph.js
+++ b/src/extras/mini-stats/graph.js
@@ -21,6 +21,9 @@ class Graph {
         this.parent = null;
         this.group = 0;
         this.headerOnly = false;
+        this.countOnly = false;
+        this.count = 0;
+        this.historyRange = 0;
         this.headerTop = 0;
         this.headerBottom = 0;
         this.lastNonZeroFrame = 0;
@@ -39,6 +42,10 @@ class Graph {
     // locked once by MiniStats, so all rows are updated before a single unlock/upload.
     update(ms, data) {
         if (this.headerOnly) return 0;
+        if (this.countOnly) {
+            if (data && this.enabled) this.updateHistory(this.count, data);
+            return 0;
+        }
         const timings = this.timer.timings;
         let total = 0;
         for (let i = 0; i < timings.length; i++) total += timings[i];
@@ -59,20 +66,32 @@ class Graph {
             this.avgCount = 0;
             this.maxValue = 0;
         }
-        if (data && this.enabled) {
-            const width = this.texture.width;
-            const rowOffset = this.yOffset * width * 4;
-            if (this.needsClear) {
-                data.fill(0, rowOffset, rowOffset + width * 4);
-                this.needsClear = false;
-            }
-            const offset = rowOffset + this.cursor * 4;
-            const range = 1.5 * (this.watermark > 0 ? this.watermark : 100);
-            data[offset] = Math.min(255, Math.max(0, Math.round(total / range * 255)));
-            data[offset + 3] = 170;
-            this.cursor = (this.cursor + 1) % width;
-        }
+        if (data && this.enabled) this.updateHistory(total, data);
         return changed;
+    }
+
+    updateHistory(value, data) {
+        const width = this.texture.width;
+        const rowOffset = this.yOffset * width * 4;
+        const range = this.countOnly ?
+            Math.max(16, this.historyRange, value > this.historyRange ? 2 ** Math.ceil(Math.log2(value)) : 0) :
+            1.5 * (this.watermark > 0 ? this.watermark : 100);
+        if (this.needsClear) {
+            data.fill(0, rowOffset, rowOffset + width * 4);
+            this.needsClear = false;
+        } else if (this.countOnly && range > this.historyRange) {
+            // Resource categories have no fixed budget. Grow their scale as needed, rescaling
+            // existing samples so a change of scale does not look like resource destruction.
+            const scale = this.historyRange / range;
+            for (let i = rowOffset; i < rowOffset + width * 4; i += 4) {
+                data[i] = Math.round(data[i] * scale);
+            }
+        }
+        this.historyRange = range;
+        const offset = rowOffset + this.cursor * 4;
+        data[offset] = Math.min(255, Math.max(0, Math.round(value / range * 255)));
+        data[offset + 3] = this.countOnly ? 255 : 170;
+        this.cursor = (this.cursor + 1) % width;
     }
 }
 

--- a/src/extras/mini-stats/mini-stats.js
+++ b/src/extras/mini-stats/mini-stats.js
@@ -33,7 +33,7 @@ const GROUP_BACKGROUND = 0xff372b22;
 const BORDER = 0xff4e3d30;
 const TEXT = 0xfffaf5f2;
 const MUTED = 0xffc8b8ad;
-const graphColors = [0xff6db1d9, 0xfff7b884, 0xffb6d16d, 0xffdda0b8, 0xff6db1d9, 0xffc8b8ad];
+const graphColors = [0xff6db1d9, 0xfff7b884, 0xffb6d16d, 0xffdda0b8, 0xff6db1d9, 0xffc8b8ad, 0xffa4cfb0];
 
 const graphOrder = (graph) => {
     if (graph.headerOnly) return 0;
@@ -82,6 +82,8 @@ const compareGraphs = (a, b) => groupOrder(a) - groupOrder(b) || graphOrder(a) -
  * @property {number} textRefreshRate - Text update interval and averaging window in ms (500 in the
  * default options). Each update shows the arithmetic mean and peak of the frame samples collected
  * since the previous update, then starts a new window. Graph history samples every frame.
+ * @property {boolean} [resourcesEnabled=true] - Show tracked resource counts in detailed views.
+ * @property {boolean} [resourcesCollapsed=true] - Initially collapse the Resources section.
  * @property {MiniStatsProcessorOptions} cpu - CPU graph options.
  * @property {MiniStatsProcessorOptions} gpu - GPU graph options.
  * @property {MiniStatsGraphOptions[]} stats - Array of options to render additional graphs based
@@ -107,7 +109,11 @@ const compareGraphs = (a, b) => groupOrder(a) - groupOrder(b) || graphOrder(a) -
  * require a debug or profiler build. See {@link AppStats} for measurement scope and availability.
  * In the detailed views, click a category heading to collapse or expand its sub-counters.
  * Click elsewhere in the overlay to change size. Collapsing a category preserves its sampling
- * and graph history.
+ * and graph history. Resources is enabled and collapsed by default, and displays current counts
+ * of existing tracked resources, including internal resources, in detailed views. Resource counts
+ * refresh at textRefreshRate while visible, including their sum in the collapsed heading; they
+ * have no average or peak. In graph views, resource histories use the latest sampled counts
+ * and scale to accommodate the highest count seen.
  */
 class MiniStats {
     /**
@@ -132,6 +138,15 @@ class MiniStats {
         this.vramGraphs = new Map();
         /** @private */
         this.collapsedGroups = new Set();
+        if (options.resourcesCollapsed ?? true) this.collapsedGroups.add(6);
+        /** @private */
+        this._resourcesEnabled = options.resourcesEnabled ?? true;
+        /** @private */
+        this._resourceElapsed = Infinity;
+        /** @type {Map<string, number>} @private */
+        this._resourceCounts = new Map();
+        /** @type {Map<string, Graph>} @private */
+        this._resourceGraphs = new Map();
         this.gpuTimingMinSize = options.gpuTimingMinSize ?? 1;
         this.cpuTimingMinSize = options.cpuTimingMinSize ?? 1;
         this.vramTimingMinSize = options.vramTimingMinSize ?? 1;
@@ -149,7 +164,7 @@ class MiniStats {
         this.clr = [1, 1, 1, 0.95];
         this.initGraphs(app, this.device, options);
 
-        const words = ['Metric', this._averageLabel, 'Peak', 'ms', 'MB'];
+        const words = ['Metric', this._averageLabel, 'Peak', 'Count', 'ms', 'MB'];
         for (const graph of this.graphs) {
             words.push(graph.label, graph.timer.unitsName || '');
         }
@@ -239,6 +254,8 @@ class MiniStats {
         this.gpuPassGraphs.clear();
         this.cpuGraphs.clear();
         this.vramGraphs.clear();
+        this._resourceGraphs.clear();
+        this._resourceCounts.clear();
         this.graphRows.clear();
         this.wordAtlas.destroy();
         this.texture.destroy();
@@ -283,6 +300,8 @@ class MiniStats {
             ],
             startSizeIndex: 0,
             textRefreshRate: 500,
+            resourcesEnabled: true,
+            resourcesCollapsed: true,
             cpu: { enabled: true, watermark: 33 },
             gpu: { enabled: true, watermark: 33 },
             stats: [
@@ -308,6 +327,7 @@ class MiniStats {
         const size = this.sizes[value];
         if (!size) return;
         this._activeSizeIndex = value;
+        this._resourceElapsed = Infinity;
         this._detailed = size.detailed ?? (value > 0 || size.graphs);
         this._showPeak = this._detailed && (size.peak ?? size.graphs);
         this.gspacing = size.spacing;
@@ -348,6 +368,7 @@ class MiniStats {
     set enabled(value) {
         if (value !== this._enabled) {
             this._enabled = value;
+            this._resourceElapsed = Infinity;
             for (let i = 0; i < this.graphs.length; i++) {
                 this.graphs[i].enabled = value && this._showGraphs;
                 this.graphs[i].timer.enabled = value;
@@ -360,6 +381,49 @@ class MiniStats {
     /** @type {boolean} */
     get enabled() {
         return this._enabled;
+    }
+
+    /**
+     * Whether the Resources section is shown in detailed views. Defaults to true. Counts use
+     * existing engine resource tracking, including internal resources, and are not a complete
+     * inventory of native GPU objects. Uniform buffers include pooled GPU backing buffers, but
+     * exclude staging buffers and individual transient allocations. Render targets are counted
+     * once initialized; WebGPU pipelines count cached entries.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.resourcesEnabled = false;
+     */
+    set resourcesEnabled(value) {
+        if (this._resourcesEnabled !== value) {
+            this._resourcesEnabled = value;
+            this._resourceElapsed = Infinity;
+            this.updateDiv();
+        }
+    }
+
+    /** @type {boolean} */
+    get resourcesEnabled() {
+        return this._resourcesEnabled;
+    }
+
+    /**
+     * Whether the Resources section is collapsed in detailed views. Defaults to true. Current
+     * counts are sampled at the configured textRefreshRate while the section is visible and
+     * MiniStats is enabled. The collapsed heading shows their sum to help spot resource growth.
+     * Changing size preserves the collapsed state.
+     *
+     * @type {boolean}
+     * @example
+     * miniStats.resourcesCollapsed = false;
+     */
+    set resourcesCollapsed(value) {
+        this.setGroupCollapsed(6, value);
+    }
+
+    /** @type {boolean} */
+    get resourcesCollapsed() {
+        return this.collapsedGroups.has(6);
     }
 
     /**
@@ -462,6 +526,7 @@ class MiniStats {
      */
     setGroupCollapsed(group, collapsed) {
         if (this.collapsedGroups.has(group) === collapsed) return;
+        if (group === 6) this._resourceElapsed = Infinity;
         if (collapsed) {
             this.collapsedGroups.add(group);
         } else {
@@ -539,6 +604,38 @@ class MiniStats {
             }
             this.graphs.push(graph);
         }
+        const resources = new Graph('Resources', app, 0, options.textRefreshRate, new StatsTimer(app, []));
+        resources.group = 6;
+        resources.headerOnly = true;
+        resources.countOnly = true;
+        /** @type {Graph} @private */
+        this._resourceGraph = resources;
+        this.graphs.push(resources);
+        const resourceLabels = new Map([
+            ['vertexBuffers', 'Vertex buffers'],
+            ['indexBuffers', 'Index buffers'],
+            ['uniformBuffers', 'Uniform buffers'],
+            ['textures', 'Textures'],
+            ['renderTargets', 'Render targets']
+        ]);
+        if (device.isWebGL2) resourceLabels.set('shaders', 'Shaders');
+        if (device.isWebGPU) {
+            resourceLabels.set('storageBuffers', 'Storage buffers');
+            resourceLabels.set('computes', 'Computes');
+            resourceLabels.set('bindGroups', 'Bind groups');
+            resourceLabels.set('bindGroupFormats', 'Bind group formats');
+            resourceLabels.set('drawCommands', 'Draw commands');
+            resourceLabels.set('renderPipelines', 'Render pipelines');
+            resourceLabels.set('computePipelines', 'Compute pipelines');
+        }
+        for (const [key, label] of resourceLabels) {
+            const graph = new Graph(label, app, 0, options.textRefreshRate, new StatsTimer(app, []));
+            graph.group = resources.group;
+            graph.parent = resources;
+            graph.countOnly = true;
+            this._resourceGraphs.set(key, graph);
+            this.graphs.push(graph);
+        }
         this.graphs.sort(compareGraphs);
         this.texture = new Texture(device, {
             name: 'mini-stats-graph-texture',
@@ -570,6 +667,17 @@ class MiniStats {
         this.updateDiv();
     }
 
+    /**
+     * @private
+     * @param {Graph} graph - The row to check.
+     * @returns {boolean} Whether the row participates in the current layout.
+     */
+    isGraphVisible(graph) {
+        if (graph.countOnly && (!this._resourcesEnabled || !this._detailed)) return false;
+        if (!this._detailed) return !graph.headerOnly;
+        return !graph.parent || !this.collapsedGroups.has(graph.group);
+    }
+
     /** @private */
     updateDiv() {
         const rect = this.device.canvas.getBoundingClientRect();
@@ -580,7 +688,7 @@ class MiniStats {
         let visibleRows = 0;
         for (let i = 0; i < this.graphs.length; i++) {
             const graph = this.graphs[i];
-            if ((!this._detailed && graph.headerOnly) || (this._detailed && graph.parent && this.collapsedGroups.has(graph.group))) continue;
+            if (!this.isGraphVisible(graph)) continue;
             const group = graph.group;
             if (this._detailed && visibleRows > 0 && group !== previousGroup) total += 5;
             total += this.height + (visibleRows ? this.gspacing : 0);
@@ -618,9 +726,34 @@ class MiniStats {
      */
     update(ms) {
         if (!this._enabled) return;
+        if (this._resourcesEnabled && this._detailed) {
+            this._resourceElapsed += ms;
+            if (this._resourceElapsed >= this.textRefreshRate) {
+                this._resourceElapsed = 0;
+                this.device.getResourceCounts(this._resourceCounts);
+                let total = 0;
+                for (const [key, graph] of this._resourceGraphs) {
+                    const count = this._resourceCounts.get(key) ?? 0;
+                    graph.count = count;
+                    total += count;
+                    const text = String(count);
+                    if (graph.timingText !== text) {
+                        graph.timingText = text;
+                        this._geometryDirty = true;
+                    }
+                }
+                const totalText = String(total);
+                if (this._resourceGraph.timingText !== totalText) {
+                    this._resourceGraph.timingText = totalText;
+                    this._geometryDirty = true;
+                }
+            }
+        }
         const data = this._showGraphs ? this.texture.lock() : null;
         for (let i = 0; i < this.graphs.length; i++) {
-            const changed = this.graphs[i].update(ms, data);
+            const graph = this.graphs[i];
+            if (graph.countOnly && (!this._resourcesEnabled || !this._detailed)) continue;
+            const changed = graph.update(ms, data);
             if (changed & (this._showPeak ? 3 : 1)) this._geometryDirty = true;
         }
         if (data) this.texture.unlock();
@@ -669,7 +802,7 @@ class MiniStats {
             const graph = this.graphs[i];
             graph.quad = -1;
             graph.headerTop = graph.headerBottom = 0;
-            if ((!this._detailed && graph.headerOnly) || (this._detailed && graph.parent && this.collapsedGroups.has(graph.group))) continue;
+            if (!this.isGraphVisible(graph)) continue;
             if (this._detailed && i > 0 && graph.group !== previousGroup) rowTop -= 5;
             const y = rowTop - this.height;
             if (y < top && rowTop > bottom) {
@@ -686,16 +819,20 @@ class MiniStats {
                 const baseline = Math.round(y + (this.height - 14) / 2 + 3);
                 const units = graph.timer.unitsName || '';
                 const showUnits = this._detailed && units && (!graph.parent || graph.parent.headerOnly);
-                const valueWidth = graph.headerOnly ? 0 : atlas.measure(graph.timingText, 1);
-                let valueRight = avgRight;
+                const hasValue = !graph.headerOnly || (graph.countOnly && this.resourcesCollapsed);
+                const valueWidth = hasValue ? atlas.measure(graph.timingText, 1) : 0;
+                let valueRight = graph.countOnly ? right : avgRight;
+                if (heading && graph.countOnly && !this.resourcesCollapsed) {
+                    atlas.render(renderer, 'Count', right - atlas.measure('Count'), baseline, 0, MUTED);
+                }
                 if (!this._detailed && units) {
                     const unitsWidth = atlas.measure(units);
                     atlas.render(renderer, units, right - unitsWidth, baseline, 0, MUTED);
                     valueRight -= unitsWidth + 4;
                 }
-                const valueX = graph.headerOnly ? right : Math.max(x + 10, valueRight - valueWidth);
-                if (!graph.headerOnly) atlas.render(renderer, graph.timingText, valueX, baseline, 1, TEXT, valueRight - valueX);
-                if (this._showPeak && !graph.headerOnly) {
+                const valueX = hasValue ? Math.max(x + 10, valueRight - valueWidth) : right;
+                if (hasValue) atlas.render(renderer, graph.timingText, valueX, baseline, 1, TEXT, valueRight - valueX);
+                if (this._showPeak && !graph.headerOnly && !graph.countOnly) {
                     const peakWidth = atlas.measure(graph.maxText);
                     atlas.render(renderer, graph.maxText, right - Math.min(peakWidth, 40), baseline, 0, MUTED, 40);
                 }

--- a/src/platform/graphics/dynamic-buffers.js
+++ b/src/platform/graphics/dynamic-buffers.js
@@ -119,6 +119,16 @@ class DynamicBuffers {
     }
 
     /**
+     * Number of backing GPU uniform buffers, including free and in-flight buffers.
+     * Staging buffers and individual suballocations are excluded.
+     *
+     * @type {number}
+     */
+    get bufferCount() {
+        return (this.gpuBuffers?.length ?? 0) + (this.usedBuffers?.length ?? 0) + (this.activeBuffer ? 1 : 0);
+    }
+
+    /**
      * Destroy the system of dynamic buffers.
      */
     destroy() {

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -28,6 +28,7 @@ import { VertexFormat } from './vertex-format.js';
 import { StencilParameters } from './stencil-parameters.js';
 import { DebugGraphics } from './debug-graphics.js';
 import { StorageBuffer } from './storage-buffer.js';
+import { UniformBuffer } from './uniform-buffer.js';
 
 /**
  * @import { Compute } from './compute.js'
@@ -811,6 +812,33 @@ class GraphicsDevice extends EventHandler {
         if (platform.mobile) capsDefines.set('PLATFORM_MOBILE', '');
         if (platform.android) capsDefines.set('PLATFORM_ANDROID', '');
         if (platform.ios) capsDefines.set('PLATFORM_IOS', '');
+    }
+
+    /**
+     * Samples existing resource registries for diagnostic overlays. Counts include internal
+     * resources; dynamic uniform buffers count backing GPU buffers, not suballocations or staging
+     * buffers. This walks the buffer registry and should only be called at diagnostic refresh rates.
+     *
+     * @param {Map<string, number>} counts - Receives the current counts, replacing previous values.
+     * @ignore
+     */
+    getResourceCounts(counts) {
+        let vertexBuffers = 0;
+        let indexBuffers = 0;
+        let uniformBuffers = this.dynamicBuffers?.bufferCount ?? 0;
+        let storageBuffers = 0;
+        for (const buffer of this.buffers) {
+            if (buffer instanceof VertexBuffer) vertexBuffers++;
+            else if (buffer instanceof IndexBuffer) indexBuffers++;
+            else if (buffer instanceof UniformBuffer) uniformBuffers++;
+            else if (buffer instanceof StorageBuffer) storageBuffers++;
+        }
+        counts.set('vertexBuffers', vertexBuffers);
+        counts.set('indexBuffers', indexBuffers);
+        counts.set('uniformBuffers', uniformBuffers);
+        counts.set('storageBuffers', storageBuffers);
+        counts.set('textures', this.textures.size);
+        counts.set('renderTargets', this.targets.size);
     }
 
     /**

--- a/src/platform/graphics/graphics-device.js
+++ b/src/platform/graphics/graphics-device.js
@@ -832,6 +832,7 @@ class GraphicsDevice extends EventHandler {
             else if (buffer instanceof IndexBuffer) indexBuffers++;
             else if (buffer instanceof UniformBuffer) uniformBuffers++;
             else if (buffer instanceof StorageBuffer) storageBuffers++;
+            else Debug.assert(false);
         }
         counts.set('vertexBuffers', vertexBuffers);
         counts.set('indexBuffers', indexBuffers);

--- a/src/platform/graphics/webgl/webgl-dynamic-buffers.js
+++ b/src/platform/graphics/webgl/webgl-dynamic-buffers.js
@@ -41,6 +41,15 @@ class WebglDynamicBuffers extends DynamicBuffers {
         super(device, 0, 0);
     }
 
+    /** @type {number} */
+    get bufferCount() {
+        let count = this.used?.length ?? 0;
+        if (this.free) {
+            for (const buffers of this.free.values()) count += buffers.length;
+        }
+        return count;
+    }
+
     destroy() {
         this.used.forEach(buffer => buffer.destroy(this.device));
         this.free.forEach(buffers => buffers.forEach(buffer => buffer.destroy(this.device)));

--- a/src/platform/graphics/webgl/webgl-graphics-device.js
+++ b/src/platform/graphics/webgl/webgl-graphics-device.js
@@ -672,6 +672,15 @@ class WebglGraphicsDevice extends GraphicsDevice {
     }
 
     /**
+     * @param {Map<string, number>} counts - Receives current tracked resource counts.
+     * @ignore
+     */
+    getResourceCounts(counts) {
+        super.getResourceCounts(counts);
+        counts.set('shaders', this.shaders.length);
+    }
+
+    /**
      * Destroy the graphics device.
      */
     destroy() {

--- a/src/platform/graphics/webgpu/webgpu-graphics-device.js
+++ b/src/platform/graphics/webgpu/webgpu-graphics-device.js
@@ -311,6 +311,25 @@ class WebgpuGraphicsDevice extends GraphicsDevice {
     }
 
     /**
+     * @param {Map<string, number>} counts - Receives current tracked resource counts.
+     * @ignore
+     */
+    getResourceCounts(counts) {
+        super.getResourceCounts(counts);
+        counts.set('bindGroups', this._bindGroups.size);
+        counts.set('bindGroupFormats', this._bindGroupFormats.size);
+        counts.set('computes', this._computes.size);
+        counts.set('drawCommands', this._drawCommands.size);
+        let renderPipelines = 0;
+        let computePipelines = 0;
+        // Hash collisions share a cache bucket, so Map.size is not the pipeline count.
+        for (const bucket of this.renderPipeline.cache.values()) renderPipelines += bucket.length;
+        for (const bucket of this.computePipeline.cache.values()) computePipelines += bucket.length;
+        counts.set('renderPipelines', renderPipelines);
+        counts.set('computePipelines', computePipelines);
+    }
+
+    /**
      * Destroy the graphics device.
      */
     destroy() {

--- a/test/extras/mini-stats/mini-stats.test.mjs
+++ b/test/extras/mini-stats/mini-stats.test.mjs
@@ -40,6 +40,185 @@ describe('MiniStats', function () {
         jsdomTeardown();
     });
 
+    it('enables Resources collapsed by default and preserves its state across sizes and toggles', function () {
+        stats = new MiniStats(app);
+        const resources = stats.graphs.find(graph => graph.name === 'Resources');
+        const query = spy(device, 'getResourceCounts');
+        expect(stats.resourcesEnabled).to.be.true;
+        expect(stats.resourcesCollapsed).to.be.true;
+        for (const mode of [0, 1, 2]) {
+            stats.activeSizeIndex = mode;
+            stats.postRender();
+            stats.update(500);
+            expect(resources.headerTop > resources.headerBottom).to.equal(mode > 0);
+            expect(query.callCount).to.equal(mode);
+        }
+        query.resetHistory();
+        stats.div.dispatchEvent(new window.MouseEvent('click', {
+            clientY: stats.div.getBoundingClientRect().bottom + 8 - (resources.headerTop + resources.headerBottom) / 2
+        }));
+        expect(stats.resourcesCollapsed).to.be.false;
+        expect(stats.activeSizeIndex).to.equal(2);
+        stats.resourcesEnabled = false;
+        stats.postRender();
+        stats.update(500);
+        expect(query.called).to.be.false;
+        expect(resources.headerTop).to.equal(0);
+        stats.resourcesEnabled = true;
+        expect(stats.resourcesCollapsed).to.be.false;
+        stats.activeSizeIndex = 0;
+        stats.update(500);
+        expect(query.called).to.be.false;
+        stats.activeSizeIndex = 1;
+        stats.update(16);
+        expect(query.calledOnce).to.be.true;
+    });
+
+    it('graphs current resource counts at visible refresh intervals without averaging or peaks', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.startSizeIndex = 2;
+        options.resourcesCollapsed = false;
+        stats = new MiniStats(app, options);
+        // Keep the entire Resources section on screen for geometry assertions.
+        stats.engineCollapsed = stats.cpuCollapsed = stats.gpuCollapsed = stats.vramCollapsed = true;
+        const query = spy(device, 'getResourceCounts');
+        const render = spy(stats.wordAtlas, 'render');
+        const textures = stats._resourceGraphs.get('textures');
+        stats.update(16);
+        stats.postRender();
+        expect(query.calledOnce).to.be.true;
+        expect(textures.timingText).to.equal(String(device.textures.size));
+        expect(render.getCalls().some(call => call.args[1] === 'Count')).to.be.true;
+        for (const graph of stats._resourceGraphs.values()) {
+            expect(stats.graphRows.has(graph)).to.be.true;
+            expect(graph.quad).to.be.at.least(0);
+            expect(graph.cursor).to.equal(1);
+            expect(graph.maxText).to.equal('—');
+        }
+        const texture = stats.texture;
+        device.textures.delete(texture);
+        stats.update(499);
+        expect(query.calledOnce).to.be.true;
+        stats.update(1);
+        expect(query.calledTwice).to.be.true;
+        expect(textures.timingText).to.equal(String(device.textures.size));
+        device.textures.add(texture);
+        stats.resourcesCollapsed = true;
+        stats.update(500);
+        stats.resourcesCollapsed = false;
+        stats.enabled = false;
+        stats.update(500);
+        expect(query.calledThrice).to.be.true;
+        stats.enabled = true;
+        stats.update(1);
+        expect(query.callCount).to.equal(4);
+        expect(textures.timingText).to.equal(String(device.textures.size));
+    });
+
+    it('preserves resource history while collapsed and pauses it in hidden or text views', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.startSizeIndex = 2;
+        stats = new MiniStats(app, options);
+        const graph = stats._resourceGraphs.get('vertexBuffers');
+        const query = spy(device, 'getResourceCounts');
+        stats.update(16);
+        stats.update(16);
+        expect(query.calledOnce).to.be.true;
+        expect(graph.cursor).to.equal(2);
+        stats.resourcesCollapsed = false;
+        stats.update(16);
+        expect(graph.cursor).to.equal(3);
+        stats.resourcesEnabled = false;
+        stats.update(500);
+        expect(graph.cursor).to.equal(3);
+        stats.resourcesEnabled = true;
+        stats.activeSizeIndex = 1;
+        stats.update(500);
+        expect(graph.cursor).to.equal(3);
+        stats.activeSizeIndex = 2;
+        stats.update(16);
+        expect(graph.cursor).to.equal(4);
+    });
+
+    it('rescales resource history without clipping large counts or changing current values', function () {
+        const graph = new Graph('Resources', app, 0, 500, new StatsTimer(app, []));
+        graph.countOnly = true;
+        graph.enabled = true;
+        graph.texture = { width: 8 };
+        const data = new Uint8ClampedArray(32);
+        graph.count = 8;
+        graph.timingText = '8';
+        graph.update(16, data);
+        const initial = data[0];
+        graph.count = 1024;
+        graph.timingText = '1024';
+        graph.update(16, data);
+        expect(graph.historyRange).to.equal(1024);
+        expect(data[0]).to.equal(Math.round(initial * 16 / 1024));
+        expect(data[4]).to.equal(255);
+        graph.count = 256;
+        graph.update(16, data);
+        expect(graph.historyRange).to.equal(1024);
+        expect(data[8]).to.equal(64);
+        expect(graph.timingText).to.equal('1024');
+        expect(graph.maxText).to.equal('—');
+    });
+
+    it('shows a live sum in the collapsed Resources heading and Count when expanded', function () {
+        const options = MiniStats.getDefaultOptions();
+        options.startSizeIndex = 1;
+        stats = new MiniStats(app, options);
+        let textures = 3;
+        const query = stub(device, 'getResourceCounts').callsFake((counts) => {
+            counts.set('vertexBuffers', 2);
+            counts.set('indexBuffers', 1);
+            counts.set('uniformBuffers', 4);
+            counts.set('textures', textures);
+            counts.set('renderTargets', 1);
+            // Only sum categories displayed for this backend.
+            counts.set('undisplayed', 1000);
+        });
+        const render = spy(stats.wordAtlas, 'render');
+        stats.update(16);
+        stats.postRender();
+        expect(stats._resourceGraph.timingText).to.equal('11');
+        expect(render.getCalls().some(call => call.args[1] === '11')).to.be.true;
+        expect(render.getCalls().some(call => call.args[1] === 'Count')).to.be.false;
+        textures = 8;
+        stats.update(499);
+        expect(query.calledOnce).to.be.true;
+        expect(stats._resourceGraph.timingText).to.equal('11');
+        stats.update(1);
+        expect(query.calledTwice).to.be.true;
+        expect(stats._resourceGraph.timingText).to.equal('16');
+        textures = 1;
+        stats.update(500);
+        expect(stats._resourceGraph.timingText).to.equal('9');
+        stats.resourcesCollapsed = false;
+        render.resetHistory();
+        stats.postRender();
+        expect(render.getCalls().some(call => call.args[1] === 'Count')).to.be.true;
+        expect(render.getCalls().some(call => call.args[1] === '9')).to.be.false;
+    });
+
+    it('accepts initial resource visibility and uses backend-specific rows', function () {
+        device.isWebGPU = true;
+        const options = MiniStats.getDefaultOptions();
+        options.resourcesEnabled = false;
+        stats = new MiniStats(app, options);
+        expect(stats.resourcesEnabled).to.be.false;
+        expect(stats._resourceGraphs.has('computes')).to.be.true;
+        expect(stats._resourceGraphs.has('renderPipelines')).to.be.true;
+        expect(stats._resourceGraphs.has('shaders')).to.be.false;
+        stats.destroy();
+        device.isWebGPU = false;
+        device.isWebGL2 = true;
+        stats = new MiniStats(app);
+        expect(stats._resourceGraphs.has('shaders')).to.be.true;
+        expect(stats._resourceGraphs.has('computes')).to.be.false;
+        expect(stats._resourceGraphs.has('renderPipelines')).to.be.false;
+    });
+
     it('groups custom counters under User above the CPU, GPU and VRAM groups', function () {
         const options = MiniStats.getDefaultOptions();
         options.stats.unshift({ name: 'Custom first', stats: ['user.first'] });
@@ -52,7 +231,7 @@ describe('MiniStats', function () {
             stats.activeSizeIndex = mode;
             stats.postRender();
             expect(stats.graphs.filter(graph => !graph.parent).map(graph => graph.label)).to.deep.equal([
-                'Engine', 'User', 'CPU', 'GPU', 'VRAM'
+                'Engine', 'User', 'CPU', 'GPU', 'VRAM', 'Resources'
             ]);
             const user = stats.graphs.find(graph => graph.headerOnly && graph.name === 'User');
             const engine = stats.graphs.find(graph => graph.headerOnly && graph.name === 'Engine');
@@ -144,7 +323,7 @@ describe('MiniStats', function () {
         stats = new MiniStats(app, options);
         expect(options.sizes[1].width).to.equal(192);
         expect(stats.sizes[1]).not.to.equal(options.sizes[1]);
-        expect(stats.graphs.filter(graph => graph.headerOnly).map(graph => graph.name)).to.deep.equal(['Engine']);
+        expect(stats.graphs.filter(graph => graph.headerOnly).map(graph => graph.name)).to.deep.equal(['Engine', 'Resources']);
     });
 
     it('supports collapse properties before sub-counters exist and keeps them synchronized with clicks', function () {
@@ -225,7 +404,7 @@ describe('MiniStats', function () {
         for (const mode of [0, 2, 1]) {
             stats.activeSizeIndex = mode;
             stats.postRender();
-            expect([...stats.collapsedGroups]).to.deep.equal([1, 3]);
+            expect([...stats.collapsedGroups]).to.deep.equal([6, 1, 3]);
             expect(stats.graphs.filter(graph => graph.parent && (graph.group === 1 || graph.group === 3)).every(graph => graph.quad === -1)).to.be.true;
         }
         // The column heading still cycles sizes.
@@ -253,7 +432,7 @@ describe('MiniStats', function () {
             clientY: stats.div.getBoundingClientRect().bottom - stats._panelHeight + 12
         }));
         expect(stats.activeSizeIndex).to.equal(0);
-        expect([...stats.collapsedGroups]).to.deep.equal([3]);
+        expect([...stats.collapsedGroups]).to.deep.equal([6, 3]);
     });
 
     it('does not interpret dragging or scrolling as a category click', function () {
@@ -269,7 +448,7 @@ describe('MiniStats', function () {
         stats.div.dispatchEvent(new window.WheelEvent('wheel', { deltaY: 100 }));
         stats.div.dispatchEvent(new window.MouseEvent('click'));
         expect(stats.activeSizeIndex).to.equal(2);
-        expect(stats.collapsedGroups.size).to.equal(0);
+        expect([...stats.collapsedGroups]).to.deep.equal([6]);
     });
 
     it('reuses cached geometry without uploads, text work or history writes in text modes', function () {
@@ -303,6 +482,9 @@ describe('MiniStats', function () {
         stats = new MiniStats(app);
         stats.activeSizeIndex = 2;
         stats.postRender();
+        // Populate initial resource counts before checking geometry between refreshes.
+        stats.update(0);
+        stats.postRender();
         const data = stats.render2d.data;
         const unlock = spy(stats.texture, 'unlock');
         const measure = spy(stats.wordAtlas, 'measure');
@@ -315,7 +497,7 @@ describe('MiniStats', function () {
         expect(upload.callCount).to.equal(10);
         expect(measure.callCount).to.equal(0);
         expect(stats.render2d.data).to.equal(data);
-        expect(stats.graphs.filter(graph => !graph.headerOnly).every(graph => graph.cursor === 10)).to.be.true;
+        expect(stats.graphs.filter(graph => !graph.headerOnly && !graph.countOnly).every(graph => graph.cursor === 11)).to.be.true;
     });
 
     it('preserves existing history when new GPU passes grow the texture', function () {
@@ -369,7 +551,7 @@ describe('MiniStats', function () {
         stats = new MiniStats(app, options);
         app.stats.gpu.set('Pass', 2);
         stats.postRender();
-        expect(stats.graphs).to.have.length(3);
+        expect(stats.graphs.filter(graph => !graph.countOnly)).to.have.length(3);
     });
 
     it('keeps the panel inside a short viewport and clamps scrolling', function () {

--- a/test/platform/graphics/resource-counts.test.mjs
+++ b/test/platform/graphics/resource-counts.test.mjs
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+
+import { INDEXFORMAT_UINT16, SEMANTIC_POSITION, TYPE_FLOAT32, UNIFORMTYPE_VEC4 } from '../../../src/platform/graphics/constants.js';
+import { DynamicBufferAllocation, DynamicBuffers } from '../../../src/platform/graphics/dynamic-buffers.js';
+import { IndexBuffer } from '../../../src/platform/graphics/index-buffer.js';
+import { NullGraphicsDevice } from '../../../src/platform/graphics/null/null-graphics-device.js';
+import { UniformBufferFormat, UniformFormat } from '../../../src/platform/graphics/uniform-buffer-format.js';
+import { UniformBuffer } from '../../../src/platform/graphics/uniform-buffer.js';
+import { VertexBuffer } from '../../../src/platform/graphics/vertex-buffer.js';
+import { VertexFormat } from '../../../src/platform/graphics/vertex-format.js';
+import { WebglDynamicBuffers } from '../../../src/platform/graphics/webgl/webgl-dynamic-buffers.js';
+import { WebgpuGraphicsDevice } from '../../../src/platform/graphics/webgpu/webgpu-graphics-device.js';
+
+describe('Tracked resource counts', function () {
+    it('reflects allocation and destruction in the existing registries', function () {
+        const device = new NullGraphicsDevice({ width: 16, height: 16 });
+        const counts = new Map();
+        device.getResourceCounts(counts);
+        const before = new Map(counts);
+        const resources = [
+            new VertexBuffer(device, new VertexFormat(device, [{ semantic: SEMANTIC_POSITION, components: 3, type: TYPE_FLOAT32 }]), 3),
+            new IndexBuffer(device, INDEXFORMAT_UINT16, 3),
+            new UniformBuffer(device, new UniformBufferFormat(device, [new UniformFormat('value', UNIFORMTYPE_VEC4)]))
+        ];
+        device.getResourceCounts(counts);
+        for (const key of ['vertexBuffers', 'indexBuffers', 'uniformBuffers']) {
+            expect(counts.get(key)).to.equal(before.get(key) + 1);
+        }
+        for (const resource of resources) resource.destroy();
+        device.getResourceCounts(counts);
+        expect(counts).to.deep.equal(before);
+        device.destroy();
+    });
+
+    it('counts WebGPU backing uniform buffers across pool states, excluding staging buffers', function () {
+        const buffers = new DynamicBuffers(null, 1024, 256);
+        buffers.gpuBuffers.push({}, {});
+        buffers.stagingBuffers.push({}, {}, {});
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.activeBuffer = { gpuBuffer: buffers.gpuBuffers.pop() };
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.scheduleSubmit();
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.gpuBuffers.push(buffers.usedBuffers.pop().gpuBuffer);
+        expect(buffers.bufferCount).to.equal(2);
+    });
+
+    it('counts WebGL pooled uniform buffers once as they are allocated and returned', function () {
+        const device = new NullGraphicsDevice({ width: 16, height: 16 });
+        const buffers = new WebglDynamicBuffers(device);
+        const first = new DynamicBufferAllocation();
+        const second = new DynamicBufferAllocation();
+        buffers.alloc(first, 16);
+        buffers.alloc(second, 32);
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.onFrameEnd();
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.alloc(first, 16);
+        expect(buffers.bufferCount).to.equal(2);
+        buffers.onFrameEnd();
+        buffers.destroy();
+        expect(buffers.bufferCount).to.equal(0);
+        device.destroy();
+    });
+
+    it('counts pipelines within collision buckets and reads cleared or replaced caches', function () {
+        const device = {
+            buffers: new Set(),
+            textures: new Set(),
+            targets: new Set(),
+            _bindGroups: new Set([{}]),
+            _bindGroupFormats: new Set([{}, {}]),
+            _computes: new Set(),
+            _drawCommands: new Set([{}]),
+            renderPipeline: { cache: new Map([[1, [{}, {}]], [2, [{}]]]) },
+            computePipeline: { cache: new Map([[1, [{}, {}]]]) }
+        };
+        const counts = new Map();
+        WebgpuGraphicsDevice.prototype.getResourceCounts.call(device, counts);
+        expect(counts.get('renderPipelines')).to.equal(3);
+        expect(counts.get('computePipelines')).to.equal(2);
+        expect(counts.get('bindGroups')).to.equal(1);
+        expect(counts.get('bindGroupFormats')).to.equal(2);
+        expect(counts.get('computes')).to.equal(0);
+        expect(counts.get('drawCommands')).to.equal(1);
+        device.renderPipeline.cache.clear();
+        device.computePipeline.cache = new Map();
+        device._bindGroups.clear();
+        WebgpuGraphicsDevice.prototype.getResourceCounts.call(device, counts);
+        expect(counts.get('renderPipelines')).to.equal(0);
+        expect(counts.get('computePipelines')).to.equal(0);
+        expect(counts.get('bindGroups')).to.equal(0);
+    });
+});


### PR DESCRIPTION
Adds a Resources section to MiniStats so developers can see tracked resource counts and spot growth over time.


<img width="253" height="811" alt="Screenshot 2026-09-11 at 12 42 17" src="https://github.com/user-attachments/assets/86d198fc-f948-42b2-ae41-2c0f07ca9247" />


**Changes:**
- Show Resources in the medium and large views, enabled and collapsed by default. The collapsed heading displays the sum; expanding shows current counts and, in the large view, history graphs that scale as counts grow.
- Display vertex, index and uniform buffers, textures and render targets on both backends; shaders on WebGL; and storage buffers, computes, bind groups, bind group formats, draw commands and cached render/compute pipelines on WebGPU.
- Use existing tracking, including internal resources. Uniform buffers include pooled GPU backing buffers, excluding staging buffers and transient suballocations. Counts describe tracked engine resources, not a complete inventory of native GPU objects.

**API Changes:**
- Add read/write `MiniStats.resourcesEnabled` and `MiniStats.resourcesCollapsed` boolean properties, both defaulting to `true`.
- Add matching optional `resourcesEnabled` and `resourcesCollapsed` constructor options.

```javascript
// Before: MiniStats has no resource-count section.
const miniStats = new pc.MiniStats(app);
```

```javascript
// After: Resources is included by default, initially collapsed.
const options = pc.MiniStats.getDefaultOptions();
options.resourcesCollapsed = false;
const miniStats = new pc.MiniStats(app, options);

// Change visibility and collapsed state at runtime.
miniStats.resourcesEnabled = false;
miniStats.resourcesCollapsed = true;
```

**Examples:**
- Update `debug/mini-stats` with controls for all eight boolean APIs: overlay visibility, resource visibility and the six collapsed sections. Controls stay synchronized with heading clicks and toolbar visibility changes.

**Performance:**
- Read existing collections at `textRefreshRate` (500 ms by default), only while Resources is enabled in a detailed view. No additional resource tracking or per-draw checks.
- Graphs use the latest sampled counts and retain history while collapsed. Resource sampling pauses when the overlay or section is disabled, or in compact mode.
