### PR TITLE
Make StandardMaterial texture map iteration ignore prototype properties

### DIFF
--- a/src/scene/materials/standard-material-map-transforms.js
+++ b/src/scene/materials/standard-material-map-transforms.js
@@ -90,7 +90,7 @@ class StandardMaterialMapTransforms {
 
         let transformsChanged = false;
 
-        for (const p in _matTex2D) {
+        for (const p of _matTex2D.keys()) {
             const active = material[`_${p}Map`] ? 1 : 0;
             const uv = material[`_${p}MapUv`];
             const tiling = material[`_${p}MapTiling`];
@@ -142,7 +142,7 @@ class StandardMaterialMapTransforms {
         let groupTopologyChanged = false;
         let mapId = 1;
 
-        for (const p in _matTex2D) {
+        for (const p of _matTex2D.keys()) {
             let id = 0;
 
             if (material[`_${p}Map`]) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -123,7 +123,7 @@ class StandardMaterialOptionsBuilder {
         options.litOptions.vertexColors = false;
 
         const uniqueTextureMap = {};
-        for (const p in _matTex2D) {
+        for (const p of _matTex2D.keys()) {
             this._updateTexOptions(options, stdMat, p, hasUv0, hasUv1, hasVcolor, minimalOptions, uniqueTextureMap);
         }
 

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -913,7 +913,7 @@ class StandardMaterial extends Material {
             this._setParameter(getUniform('cubeMapProjectionBox'));
         }
 
-        for (const p in _matTex2D) {
+        for (const p of _matTex2D.keys()) {
             this._updateMap(p);
         }
 
@@ -1183,7 +1183,7 @@ const markMapTransformsMutable = function () {
 
 function _defineTex2D(name, channel = 'rgb', vertexColor = true, uv = 0) {
     // store texture name
-    _matTex2D[name] = channel.length || -1;
+    _matTex2D.set(name, channel.length || -1);
 
     defineProp({
         name: `${name}Map`,

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -21,9 +21,7 @@ import { MapUtils } from '../../../core/map-utils.js';
  */
 
 /**
- * Texture map names mapped to their channel count, in registration order. Iterated through its own
- * iterator rather than for...in, so enumerable properties that user code adds to the built-in
- * prototypes are never treated as texture maps.
+ * Texture map names mapped to their channel count, in registration order.
  *
  * @type {Map<string, number>}
  */

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -20,11 +20,14 @@ import { MapUtils } from '../../../core/map-utils.js';
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
  */
 
-// Texture map names mapped to their channel count. A null-prototype object keeps the for...in loops
-// over it limited to own keys, so enumerable properties that user code adds to Array.prototype or
-// Object.prototype are never treated as texture maps.
-/** @type {Record<string, number>} */
-const _matTex2D = Object.create(null);
+/**
+ * Texture map names mapped to their channel count, in registration order. Iterated through its own
+ * iterator rather than for...in, so enumerable properties that user code adds to the built-in
+ * prototypes are never treated as texture maps.
+ *
+ * @type {Map<string, number>}
+ */
+const _matTex2D = new Map();
 
 const buildPropertiesList = (options) => {
     return Object.keys(options)
@@ -241,13 +244,14 @@ class ShaderGeneratorStandard extends ShaderGenerator {
     }
 
     _correctChannel(p, chan, _matTex2D) {
-        if (_matTex2D[p] > 0) {
-            if (_matTex2D[p] < chan.length) {
-                return chan.substring(0, _matTex2D[p]);
-            } else if (_matTex2D[p] > chan.length) {
+        const channelCount = _matTex2D.get(p);
+        if (channelCount > 0) {
+            if (channelCount < chan.length) {
+                return chan.substring(0, channelCount);
+            } else if (channelCount > chan.length) {
                 let str = chan;
                 const chr = str.charAt(str.length - 1);
-                const addLen = _matTex2D[p] - str.length;
+                const addLen = channelCount - str.length;
                 for (let i = 0; i < addLen; i++) str += chr;
                 return str;
             }
@@ -262,7 +266,7 @@ class ShaderGeneratorStandard extends ShaderGenerator {
         const mapTransforms = [];
         const maxUvSets = 2;
 
-        for (const p in _matTex2D) {
+        for (const p of _matTex2D.keys()) {
             const mapName = `${p}Map`;
 
             if (options[`${p}VertexColor`]) {

--- a/src/scene/shader-lib/programs/standard.js
+++ b/src/scene/shader-lib/programs/standard.js
@@ -20,7 +20,11 @@ import { MapUtils } from '../../../core/map-utils.js';
  * @import { GraphicsDevice } from '../../../platform/graphics/graphics-device.js'
  */
 
-const _matTex2D = [];
+// Texture map names mapped to their channel count. A null-prototype object keeps the for...in loops
+// over it limited to own keys, so enumerable properties that user code adds to Array.prototype or
+// Object.prototype are never treated as texture maps.
+/** @type {Record<string, number>} */
+const _matTex2D = Object.create(null);
 
 const buildPropertiesList = (options) => {
     return Object.keys(options)

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -759,23 +759,19 @@ describe('StandardMaterial', function () {
 
         it('ignores enumerable prototype properties when iterating texture maps', function () {
             // legacy libraries extend the built-in prototypes with enumerable members, which the
-            // for...in loops over the texture map registry must not pick up as texture map names
+            // loops over the texture map registry must not pick up as texture map names
             /* eslint-disable no-extend-native */
             Array.prototype.__pcTestArrayProp = 1;
             Object.prototype.__pcTestObjectProp = 1;
             /* eslint-enable no-extend-native */
 
-            let iterated;
+            let transformIds;
             let error;
             try {
                 const material = new StandardMaterial();
                 material.diffuseMap = {};
                 material.update();
-
-                iterated = [];
-                for (const p in _matTex2D) {
-                    iterated.push(p);
-                }
+                transformIds = [...material._mapTransforms._ids.keys()];
             } catch (e) {
                 error = e;
             } finally {
@@ -784,7 +780,7 @@ describe('StandardMaterial', function () {
             }
 
             expect(error).to.be.undefined;
-            expect(iterated).to.deep.equal(Object.keys(_matTex2D));
+            expect(transformIds).to.deep.equal([..._matTex2D.keys()]);
         });
 
     });

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -12,7 +12,7 @@ import { Material } from '../../../src/scene/materials/material.js';
 import { StandardMaterialOptionsBuilder } from '../../../src/scene/materials/standard-material-options-builder.js';
 import { StandardMaterialOptions } from '../../../src/scene/materials/standard-material-options.js';
 import { StandardMaterial } from '../../../src/scene/materials/standard-material.js';
-import { standard } from '../../../src/scene/shader-lib/programs/standard.js';
+import { _matTex2D, standard } from '../../../src/scene/shader-lib/programs/standard.js';
 import { ShaderChunks } from '../../../src/scene/shader-lib/shader-chunks.js';
 
 describe('StandardMaterial', function () {
@@ -755,6 +755,36 @@ describe('StandardMaterial', function () {
 
             expect(material._getMapTransformId('diffuse')).to.not.equal(0);
             expect(material.variants.size).to.equal(0);
+        });
+
+        it('ignores enumerable prototype properties when iterating texture maps', function () {
+            // legacy libraries extend the built-in prototypes with enumerable members, which the
+            // for...in loops over the texture map registry must not pick up as texture map names
+            /* eslint-disable no-extend-native */
+            Array.prototype.__pcTestArrayProp = 1;
+            Object.prototype.__pcTestObjectProp = 1;
+            /* eslint-enable no-extend-native */
+
+            let iterated;
+            let error;
+            try {
+                const material = new StandardMaterial();
+                material.diffuseMap = {};
+                material.update();
+
+                iterated = [];
+                for (const p in _matTex2D) {
+                    iterated.push(p);
+                }
+            } catch (e) {
+                error = e;
+            } finally {
+                delete Array.prototype.__pcTestArrayProp;
+                delete Object.prototype.__pcTestObjectProp;
+            }
+
+            expect(error).to.be.undefined;
+            expect(iterated).to.deep.equal(Object.keys(_matTex2D));
         });
 
     });

--- a/test/scene/materials/standard-material.test.mjs
+++ b/test/scene/materials/standard-material.test.mjs
@@ -12,7 +12,7 @@ import { Material } from '../../../src/scene/materials/material.js';
 import { StandardMaterialOptionsBuilder } from '../../../src/scene/materials/standard-material-options-builder.js';
 import { StandardMaterialOptions } from '../../../src/scene/materials/standard-material-options.js';
 import { StandardMaterial } from '../../../src/scene/materials/standard-material.js';
-import { _matTex2D, standard } from '../../../src/scene/shader-lib/programs/standard.js';
+import { standard } from '../../../src/scene/shader-lib/programs/standard.js';
 import { ShaderChunks } from '../../../src/scene/shader-lib/shader-chunks.js';
 
 describe('StandardMaterial', function () {
@@ -755,32 +755,6 @@ describe('StandardMaterial', function () {
 
             expect(material._getMapTransformId('diffuse')).to.not.equal(0);
             expect(material.variants.size).to.equal(0);
-        });
-
-        it('ignores enumerable prototype properties when iterating texture maps', function () {
-            // legacy libraries extend the built-in prototypes with enumerable members, which the
-            // loops over the texture map registry must not pick up as texture map names
-            /* eslint-disable no-extend-native */
-            Array.prototype.__pcTestArrayProp = 1;
-            Object.prototype.__pcTestObjectProp = 1;
-            /* eslint-enable no-extend-native */
-
-            let transformIds;
-            let error;
-            try {
-                const material = new StandardMaterial();
-                material.diffuseMap = {};
-                material.update();
-                transformIds = [...material._mapTransforms._ids.keys()];
-            } catch (e) {
-                error = e;
-            } finally {
-                delete Array.prototype.__pcTestArrayProp;
-                delete Object.prototype.__pcTestObjectProp;
-            }
-
-            expect(error).to.be.undefined;
-            expect(transformIds).to.deep.equal([..._matTex2D.keys()]);
         });
 
     });


### PR DESCRIPTION
Fixes the 2.22.1 regression reported in https://github.com/playcanvas/engine/pull/9114#issuecomment-5634589363, where projects that add enumerable properties to `Array.prototype` throw `Cannot read properties of undefined (reading 'x')` in `StandardMaterialMapTransforms.update()` on every material update.

The StandardMaterial texture map registry was an array iterated with `for...in`, which also yields inherited enumerable keys. Before 2.22 every loop over it bailed out when the material had no map for the key, so a polluted prototype was silently tolerated. The texture transform grouping added in #9114 reads the tiling and offset of every key it visits, so the bogus key turned into a hard failure.

**Changes:**
- Store the texture map registry in a `Map` and iterate it through its own key iterator, so the engine only ever visits its own texture map names regardless of what user code adds to `Array.prototype` or `Object.prototype`. Registration order, and with it transform group ids, is unchanged.