### PR TITLE
Add a material bind group slot and cached shader processing keys

### DIFF
--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -110,7 +110,7 @@ class BindStorageBufferFormat extends BindBaseFormat {
 
     /** @ignore */
     get key() {
-        return `SB${super.key}:${this.readOnly ? 1 : 0}`;
+        return `SB${super.key}:${this.readOnly ? 1 : 0}:${this.format}`;
     }
 }
 
@@ -356,10 +356,10 @@ class BindGroupFormat {
             }
         });
 
-        /** @type {GraphicsDevice} */
         // the slots are assigned above, so the resource keys are complete
         this.key = formats.map(format => format.key).join(',');
 
+        /** @type {GraphicsDevice} */
         this.device = graphicsDevice;
         const scope = graphicsDevice.scope;
 

--- a/src/platform/graphics/bind-group-format.js
+++ b/src/platform/graphics/bind-group-format.js
@@ -46,6 +46,19 @@ class BindBaseFormat {
         // SHADERSTAGE_VERTEX, SHADERSTAGE_FRAGMENT, SHADERSTAGE_COMPUTE
         this.visibility = visibility;
     }
+
+    /**
+     * A string describing the resource for the purpose of keying caches of shaders processed
+     * against it. Subclasses prefix it with the kind of the resource and append the properties
+     * that select their shader declaration. Valid once the slot has been assigned by the
+     * {@link BindGroupFormat}.
+     *
+     * @type {string}
+     * @ignore
+     */
+    get key() {
+        return `${this.slot}:${this.name}:${this.visibility}`;
+    }
 }
 
 /**
@@ -54,6 +67,10 @@ class BindBaseFormat {
  * @category Graphics
  */
 class BindUniformBufferFormat extends BindBaseFormat {
+    /** @ignore */
+    get key() {
+        return `U${super.key}`;
+    }
 }
 
 /**
@@ -89,6 +106,11 @@ class BindStorageBufferFormat extends BindBaseFormat {
         // whether the buffer is read-only
         this.readOnly = readOnly;
         Debug.assert(readOnly || !(visibility & SHADERSTAGE_VERTEX), 'Storage buffer can only be used in read-only mode in SHADERSTAGE_VERTEX.');
+    }
+
+    /** @ignore */
+    get key() {
+        return `SB${super.key}:${this.readOnly ? 1 : 0}`;
     }
 }
 
@@ -187,6 +209,12 @@ class BindTextureFormat extends BindBaseFormat {
             Debug.assert(textureDimension === TEXTUREDIMENSION_2D, `Multisampled texture binding '${name}' requires TEXTUREDIMENSION_2D.`);
         }
     }
+
+    /** @ignore */
+    get key() {
+        const sampler = this.hasSampler ? this.samplerName : '';
+        return `T${super.key}:${this.textureDimension}:${this.sampleType}:${sampler}:${this.multisampled ? 1 : 0}`;
+    }
 }
 
 /**
@@ -236,6 +264,11 @@ class BindStorageTextureFormat extends BindBaseFormat {
         // whether the texture is readable
         this.read = read;
     }
+
+    /** @ignore */
+    get key() {
+        return `ST${super.key}:${this.format}:${this.textureDimension}:${this.write ? 1 : 0}:${this.read ? 1 : 0}`;
+    }
 }
 
 /**
@@ -276,6 +309,16 @@ class BindGroupFormat {
     storageBufferFormats = [];
 
     /**
+     * A string uniquely describing the resources of the format (their kinds, names, slots and
+     * the properties that select the shader declaration), used to key caches of shaders
+     * processed against this format.
+     *
+     * @type {string}
+     * @ignore
+     */
+    key;
+
+    /**
      * Create a new instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device used to manage this vertex format.
@@ -314,6 +357,9 @@ class BindGroupFormat {
         });
 
         /** @type {GraphicsDevice} */
+        // the slots are assigned above, so the resource keys are complete
+        this.key = formats.map(format => format.key).join(',');
+
         this.device = graphicsDevice;
         const scope = graphicsDevice.scope;
 

--- a/src/platform/graphics/constants.js
+++ b/src/platform/graphics/constants.js
@@ -2361,11 +2361,12 @@ export const TEXPROPERTY_ALL = 255; // 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128
 
 // indices of commonly used bind groups, sorted from the least commonly changing to avoid internal rebinding
 export const BINDGROUP_VIEW = 0;        // view bind group, textures, samplers and uniforms
-export const BINDGROUP_MESH = 1;        // mesh bind group - textures and samplers
-export const BINDGROUP_MESH_UB = 2;     // mesh bind group - a single uniform buffer
+export const BINDGROUP_MATERIAL = 1;    // material bind group - reserved for the material uniform buffer and textures, bound empty until materials own one
+export const BINDGROUP_MESH = 2;        // mesh bind group - textures and samplers
+export const BINDGROUP_MESH_UB = 3;     // mesh bind group - a single uniform buffer
 
 // names of bind groups
-export const bindGroupNames = ['view', 'mesh', 'mesh_ub'];
+export const bindGroupNames = ['view', 'material', 'mesh', 'mesh_ub'];
 
 // name of the default uniform buffer slot in a bind group
 export const UNIFORM_BUFFER_DEFAULT_SLOT_NAME = 'default';

--- a/src/platform/graphics/shader-chunks/frag/webgpu-clear.js
+++ b/src/platform/graphics/shader-chunks/frag/webgpu-clear.js
@@ -1,5 +1,7 @@
 // Shader used by WebgpuClearRenderer to clear the color and / or depth of the viewport area, by
 // rendering a fullscreen quad.
+import { BINDGROUP_MESH_UB } from '../../constants.js';
+
 export default /* wgsl */`
 
     struct ub_mesh {
@@ -7,7 +9,7 @@ export default /* wgsl */`
         depth: f32
     }
 
-    @group(2) @binding(0) var<uniform> ubMesh : ub_mesh;
+    @group(${BINDGROUP_MESH_UB}) @binding(0) var<uniform> ubMesh : ub_mesh;
 
     var<private> pos : array<vec2f, 4> = array<vec2f, 4>(
         vec2(-1.0, 1.0), vec2(1.0, 1.0), vec2(-1.0, -1.0), vec2(1.0, -1.0)

--- a/src/platform/graphics/shader-processor-options.js
+++ b/src/platform/graphics/shader-processor-options.js
@@ -85,13 +85,26 @@ class ShaderProcessorOptions {
      * @returns {string} - Returns the key.
      */
     generateKey(device) {
-        // TODO: Optimize. Uniform and BindGroup formats should have their keys evaluated in their
-        // constructors, and here we should simply concatenate those.
-        let key = JSON.stringify(this.uniformFormats) + JSON.stringify(this.bindGroupFormats);
+        // the formats describe their layout in a key computed once in their constructors, and
+        // the bind group index they are assigned to is part of the emitted declaration
+        let key = '';
+        const { uniformFormats, bindGroupFormats } = this;
+        for (let i = 0; i < uniformFormats.length; i++) {
+            const format = uniformFormats[i];
+            if (format) {
+                key += `|u${i}:${format.key}`;
+            }
+        }
+        for (let i = 0; i < bindGroupFormats.length; i++) {
+            const format = bindGroupFormats[i];
+            if (format) {
+                key += `|b${i}:${format.key}`;
+            }
+        }
 
         // WebGPU shaders are processed per vertex format
         if (device.isWebGPU) {
-            key += this.vertexFormat?.shaderProcessingHashString;
+            key += `|v:${this.vertexFormat?.shaderProcessingHashString}`;
         }
 
         return key;

--- a/src/platform/graphics/uniform-buffer-format.js
+++ b/src/platform/graphics/uniform-buffer-format.js
@@ -217,6 +217,15 @@ class UniformBufferFormat {
     map = new Map();
 
     /**
+     * A string uniquely describing the layout of the buffer (the names, types and array sizes
+     * of its uniforms, in order), used to key caches of shaders processed against this format.
+     *
+     * @type {string}
+     * @ignore
+     */
+    key;
+
+    /**
      * Create a new UniformBufferFormat instance.
      *
      * @param {GraphicsDevice} graphicsDevice - The graphics device.
@@ -243,6 +252,8 @@ class UniformBufferFormat {
 
         // round up buffer size
         this.byteSize = math.roundUp(offset, 16);
+
+        this.key = uniforms.map(uniform => `${uniform.name}:${uniform.type}:${uniform.count}`).join(',');
     }
 
     /**

--- a/src/platform/graphics/webgpu/webgpu-clear-renderer.js
+++ b/src/platform/graphics/webgpu/webgpu-clear-renderer.js
@@ -4,7 +4,7 @@ import { BlendState } from '../blend-state.js';
 import {
     PRIMITIVE_TRISTRIP, SHADERLANGUAGE_WGSL,
     UNIFORMTYPE_FLOAT, UNIFORMTYPE_VEC4, BINDGROUP_MESH, CLEARFLAG_COLOR, CLEARFLAG_DEPTH, CLEARFLAG_STENCIL,
-    BINDGROUP_MESH_UB
+    BINDGROUP_MESH_UB, BINDGROUP_MATERIAL
 } from '../constants.js';
 import { Shader } from '../shader.js';
 import { DynamicBindGroup } from '../bind-group.js';
@@ -76,6 +76,9 @@ class WebgpuClearRenderer {
 
             // not using mesh bind group
             device.setBindGroup(BINDGROUP_MESH, device.emptyBindGroup);
+
+            // not using material bind group
+            device.setBindGroup(BINDGROUP_MATERIAL, device.emptyBindGroup);
 
             // setup clear color
             let blendState;

--- a/src/platform/graphics/webgpu/webgpu-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-pipeline.js
@@ -27,10 +27,14 @@ class WebgpuPipeline {
      */
     getPipelineLayout(bindGroupFormats) {
 
+        // the layout cannot skip an index - a gap would shift every following bind group to a
+        // wrong slot, so each index up to the highest bound group needs a format
         const bindGroupLayouts = [];
-        bindGroupFormats.forEach((format) => {
+        for (let i = 0; i < bindGroupFormats.length; i++) {
+            const format = bindGroupFormats[i];
+            Debug.assert(format, `Bind group format at index ${i} is not set, the pipeline layout cannot have a gap.`);
             bindGroupLayouts.push(format.bindGroupLayout);
-        });
+        }
 
         const desc = {
             bindGroupLayouts: bindGroupLayouts

--- a/src/platform/graphics/webgpu/webgpu-render-pipeline.js
+++ b/src/platform/graphics/webgpu/webgpu-render-pipeline.js
@@ -142,7 +142,7 @@ class CacheEntry {
 }
 
 class WebgpuRenderPipeline extends WebgpuPipeline {
-    lookupHashes = new Uint32Array(16);
+    lookupHashes = new Uint32Array(17);
 
     constructor(device) {
         super(device);
@@ -184,7 +184,7 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
     get(primitive, vertexFormat0, vertexFormat1, ibFormat, shader, renderTarget, bindGroupFormats, blendState,
         depthState, cullMode, stencilEnabled, stencilFront, stencilBack, frontFace, alphaToCoverage) {
 
-        Debug.assert(bindGroupFormats.length <= 3);
+        Debug.assert(bindGroupFormats.length <= bindGroupNames.length);
 
         // ibFormat is used only for stripped primitives, clear it otherwise to avoid additional render pipelines
         const primitiveType = primitive.type;
@@ -194,9 +194,11 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
 
         // all bind groups must be set as the WebGPU layout cannot have skipped indices. Not having a bind
         // group would assign incorrect slots to the following bind groups, causing a validation errors.
-        Debug.assert(bindGroupFormats[0], `BindGroup with index 0 [${bindGroupNames[0]}] is not set.`);
-        Debug.assert(bindGroupFormats[1], `BindGroup with index 1 [${bindGroupNames[1]}] is not set.`);
-        Debug.assert(bindGroupFormats[2], `BindGroup with index 2 [${bindGroupNames[2]}] is not set.`);
+        Debug.call(() => {
+            for (let i = 0; i < bindGroupNames.length; i++) {
+                Debug.assert(bindGroupFormats[i], `BindGroup with index ${i} [${bindGroupNames[i]}] is not set.`);
+            }
+        });
 
         // alpha to coverage is dropped when the render target cannot support it, so the effective
         // state is what needs to take part in the hash
@@ -215,11 +217,12 @@ class WebgpuRenderPipeline extends WebgpuPipeline {
         lookupHashes[8] = bindGroupFormats[0]?.key ?? 0;
         lookupHashes[9] = bindGroupFormats[1]?.key ?? 0;
         lookupHashes[10] = bindGroupFormats[2]?.key ?? 0;
-        lookupHashes[11] = stencilEnabled ? stencilFront.key : 0;
-        lookupHashes[12] = stencilEnabled ? stencilBack.key : 0;
-        lookupHashes[13] = ibFormat ?? 0;
-        lookupHashes[14] = frontFace;
-        lookupHashes[15] = alphaToCoverageEnabled ? 1 : 0;
+        lookupHashes[11] = bindGroupFormats[3]?.key ?? 0;
+        lookupHashes[12] = stencilEnabled ? stencilFront.key : 0;
+        lookupHashes[13] = stencilEnabled ? stencilBack.key : 0;
+        lookupHashes[14] = ibFormat ?? 0;
+        lookupHashes[15] = frontFace;
+        lookupHashes[16] = alphaToCoverageEnabled ? 1 : 0;
         const hash = hash32Fnv1a(lookupHashes);
 
         // cached pipeline

--- a/src/scene/graphics/quad-render.js
+++ b/src/scene/graphics/quad-render.js
@@ -1,7 +1,7 @@
 import { Debug, DebugHelper } from '../../core/debug.js';
 import { Vec4 } from '../../core/math/vec4.js';
 import { BindGroup, DynamicBindGroup } from '../../platform/graphics/bind-group.js';
-import { BINDGROUP_MESH, BINDGROUP_MESH_UB, BINDGROUP_VIEW, PRIMITIVE_TRIANGLES } from '../../platform/graphics/constants.js';
+import { BINDGROUP_MESH, BINDGROUP_MESH_UB, BINDGROUP_MATERIAL, BINDGROUP_VIEW, PRIMITIVE_TRIANGLES } from '../../platform/graphics/constants.js';
 import { DebugGraphics } from '../../platform/graphics/debug-graphics.js';
 import { ShaderProcessorOptions } from '../../platform/graphics/shader-processor-options.js';
 import { UniformBuffer } from '../../platform/graphics/uniform-buffer.js';
@@ -146,6 +146,9 @@ class QuadRender {
 
             // not using view bind group
             device.setBindGroup(BINDGROUP_VIEW, device.emptyBindGroup);
+
+            // not using material bind group
+            device.setBindGroup(BINDGROUP_MATERIAL, device.emptyBindGroup);
 
             // mesh bind group
             const bindGroup = this.bindGroup;

--- a/src/scene/renderer/renderer.js
+++ b/src/scene/renderer/renderer.js
@@ -11,7 +11,7 @@ import {
     BINDGROUP_MESH, BINDGROUP_VIEW,
     UNIFORMTYPE_MAT4, UNIFORMTYPE_MAT3, UNIFORMTYPE_VEC4, UNIFORMTYPE_VEC3, UNIFORMTYPE_IVEC3, UNIFORMTYPE_VEC2, UNIFORMTYPE_FLOAT, UNIFORMTYPE_INT, UNIFORMTYPE_UINT,
     CULLFACE_NONE,
-    BINDGROUP_MESH_UB,
+    BINDGROUP_MESH_UB, BINDGROUP_MATERIAL,
     FRONTFACE_CCW,
     FRONTFACE_CW
 } from '../../platform/graphics/constants.js';
@@ -755,6 +755,12 @@ class Renderer {
         Debug.assert(viewUniformFormat);
         const { device } = this;
         const ub = this.getViewUniformBuffer(viewUniformFormat);
+
+        // the material bind group is reserved for the material uniform buffer, which no material
+        // owns yet - bind it empty so the pipeline layout has no gap at its index
+        if (device.supportsUniformBuffers) {
+            device.setBindGroup(BINDGROUP_MATERIAL, device.emptyBindGroup);
+        }
 
         if (viewList) {
 

--- a/test/platform/graphics/bind-group-format.test.mjs
+++ b/test/platform/graphics/bind-group-format.test.mjs
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { BindGroupFormat, BindTextureFormat } from '../../../src/platform/graphics/bind-group-format.js';
+import { BindGroupFormat, BindStorageBufferFormat, BindTextureFormat } from '../../../src/platform/graphics/bind-group-format.js';
 import {
-    SAMPLETYPE_FLOAT, SAMPLETYPE_UNFILTERABLE_FLOAT, SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D
+    SAMPLETYPE_FLOAT, SAMPLETYPE_UNFILTERABLE_FLOAT, SHADERSTAGE_COMPUTE, SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D
 } from '../../../src/platform/graphics/constants.js';
 import { ScopeSpace } from '../../../src/platform/graphics/scope-space.js';
 
@@ -113,6 +113,24 @@ describe('BindTextureFormat', function () {
             expect(unfilterable.key).to.not.equal(base.key);
             expect(reordered.key).to.not.equal(base.key);
             [base, renamed, noSampler, unfilterable, reordered].forEach(f => f.destroy());
+        });
+
+        it('differs when a storage buffer element type or access mode differs', function () {
+            const device = createDevice();
+            const storage = (type, readOnly = true) => {
+                const format = new BindStorageBufferFormat('data', SHADERSTAGE_COMPUTE, readOnly);
+                format.format = type;
+                return format;
+            };
+            const u32 = new BindGroupFormat(device, [storage('array<u32>')]);
+            const sameType = new BindGroupFormat(device, [storage('array<u32>')]);
+            const vec4 = new BindGroupFormat(device, [storage('array<vec4f>')]);
+            const writable = new BindGroupFormat(device, [storage('array<u32>', false)]);
+
+            expect(sameType.key).to.equal(u32.key);
+            expect(vec4.key).to.not.equal(u32.key);
+            expect(writable.key).to.not.equal(u32.key);
+            [u32, sameType, vec4, writable].forEach(f => f.destroy());
         });
 
         it('is empty for a format without resources', function () {

--- a/test/platform/graphics/bind-group-format.test.mjs
+++ b/test/platform/graphics/bind-group-format.test.mjs
@@ -77,4 +77,49 @@ describe('BindTextureFormat', function () {
             format.destroy();
         });
     });
+
+    describe('BindGroupFormat key', function () {
+
+        const createDevice = () => {
+            let implKey = 0;
+            return {
+                scope: new ScopeSpace('test'),
+                createBindGroupFormatImpl() {
+                    return { key: implKey++, destroy() {} };
+                }
+            };
+        };
+
+        it('is the same for formats describing the same resources', function () {
+            const device = createDevice();
+            const a = new BindGroupFormat(device, [new BindTextureFormat('color', SHADERSTAGE_FRAGMENT), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT, false)]);
+            const b = new BindGroupFormat(device, [new BindTextureFormat('color', SHADERSTAGE_FRAGMENT), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT, false)]);
+            expect(a.key).to.be.a('string').that.is.not.empty;
+            expect(a.key).to.equal(b.key);
+            a.destroy();
+            b.destroy();
+        });
+
+        it('differs when a texture name, sampler, sample type or order differs', function () {
+            const device = createDevice();
+            const base = new BindGroupFormat(device, [new BindTextureFormat('color', SHADERSTAGE_FRAGMENT), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT)]);
+            const renamed = new BindGroupFormat(device, [new BindTextureFormat('albedo', SHADERSTAGE_FRAGMENT), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT)]);
+            const noSampler = new BindGroupFormat(device, [new BindTextureFormat('color', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_FLOAT, false), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT)]);
+            const unfilterable = new BindGroupFormat(device, [new BindTextureFormat('color', SHADERSTAGE_FRAGMENT, TEXTUREDIMENSION_2D, SAMPLETYPE_UNFILTERABLE_FLOAT), new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT)]);
+            const reordered = new BindGroupFormat(device, [new BindTextureFormat('depth', SHADERSTAGE_FRAGMENT), new BindTextureFormat('color', SHADERSTAGE_FRAGMENT)]);
+
+            expect(renamed.key).to.not.equal(base.key);
+            expect(noSampler.key).to.not.equal(base.key);
+            expect(unfilterable.key).to.not.equal(base.key);
+            expect(reordered.key).to.not.equal(base.key);
+            [base, renamed, noSampler, unfilterable, reordered].forEach(f => f.destroy());
+        });
+
+        it('is empty for a format without resources', function () {
+            const device = createDevice();
+            const empty = new BindGroupFormat(device, []);
+            expect(empty.key).to.equal('');
+            empty.destroy();
+        });
+    });
 });

--- a/test/platform/graphics/shader-processor-options.test.mjs
+++ b/test/platform/graphics/shader-processor-options.test.mjs
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+
+import { BindGroupFormat, BindTextureFormat } from '../../../src/platform/graphics/bind-group-format.js';
+import {
+    BINDGROUP_MATERIAL, BINDGROUP_MESH, BINDGROUP_MESH_UB, BINDGROUP_VIEW, bindGroupNames,
+    SHADERSTAGE_FRAGMENT, UNIFORMTYPE_FLOAT, UNIFORMTYPE_MAT4, UNIFORMTYPE_VEC3
+} from '../../../src/platform/graphics/constants.js';
+import { ScopeSpace } from '../../../src/platform/graphics/scope-space.js';
+import { ShaderProcessorOptions } from '../../../src/platform/graphics/shader-processor-options.js';
+import { UniformBufferFormat, UniformFormat } from '../../../src/platform/graphics/uniform-buffer-format.js';
+
+describe('bind group indices', function () {
+
+    it('are contiguous and match the bind group names', function () {
+        expect(BINDGROUP_VIEW).to.equal(0);
+        expect(BINDGROUP_MATERIAL).to.equal(1);
+        expect(BINDGROUP_MESH).to.equal(2);
+        expect(BINDGROUP_MESH_UB).to.equal(3);
+        expect(bindGroupNames).to.deep.equal(['view', 'material', 'mesh', 'mesh_ub']);
+    });
+
+});
+
+describe('ShaderProcessorOptions', function () {
+
+    const webgl = { isWebGPU: false };
+    const webgpu = { isWebGPU: true };
+
+    const createDevice = () => {
+        let implKey = 0;
+        return {
+            scope: new ScopeSpace('test'),
+            createBindGroupFormatImpl() {
+                return { key: implKey++, destroy() {} };
+            }
+        };
+    };
+
+    const viewFormat = (device, uniforms = [new UniformFormat('matrix_viewProjection', UNIFORMTYPE_MAT4)]) => {
+        return new UniformBufferFormat(device, uniforms);
+    };
+
+    describe('#generateKey', function () {
+
+        it('is identical for options built from equivalent formats', function () {
+            const device = createDevice();
+            const a = new ShaderProcessorOptions(viewFormat(device));
+            const b = new ShaderProcessorOptions(viewFormat(device));
+            expect(a.generateKey(webgl)).to.equal(b.generateKey(webgl));
+        });
+
+        it('differs when the view uniform format layout differs', function () {
+            const device = createDevice();
+            const a = new ShaderProcessorOptions(viewFormat(device));
+            const b = new ShaderProcessorOptions(viewFormat(device, [
+                new UniformFormat('matrix_viewProjection', UNIFORMTYPE_MAT4),
+                new UniformFormat('view_position', UNIFORMTYPE_VEC3)
+            ]));
+            expect(a.generateKey(webgl)).to.not.equal(b.generateKey(webgl));
+        });
+
+        it('differs when the same bind group format is assigned to another bind group index', function () {
+            const device = createDevice();
+            const textures = [new BindTextureFormat('sceneColor', SHADERSTAGE_FRAGMENT)];
+
+            const a = new ShaderProcessorOptions(viewFormat(device));
+            a.bindGroupFormats[BINDGROUP_VIEW] = new BindGroupFormat(device, textures);
+
+            const b = new ShaderProcessorOptions(viewFormat(device));
+            b.bindGroupFormats[BINDGROUP_MATERIAL] = new BindGroupFormat(device, textures);
+
+            expect(a.generateKey(webgl)).to.not.equal(b.generateKey(webgl));
+        });
+
+        it('includes the vertex format only on WebGPU', function () {
+            const device = createDevice();
+            const withFormat = new ShaderProcessorOptions(viewFormat(device), { shaderProcessingHashString: 'position' });
+            const withoutFormat = new ShaderProcessorOptions(viewFormat(device));
+
+            expect(withFormat.generateKey(webgl)).to.equal(withoutFormat.generateKey(webgl));
+            expect(withFormat.generateKey(webgpu)).to.not.equal(withoutFormat.generateKey(webgpu));
+        });
+
+        it('does not depend on the identity of the format objects', function () {
+            const device = createDevice();
+            const options = new ShaderProcessorOptions(viewFormat(device));
+            const key = options.generateKey(webgl);
+
+            // a new set of formats with the same layout reproduces the key
+            const other = new ShaderProcessorOptions(viewFormat(device, [new UniformFormat('matrix_viewProjection', UNIFORMTYPE_MAT4)]));
+            expect(other.generateKey(webgl)).to.equal(key);
+
+            // while a type change of a single uniform does not
+            const changed = new ShaderProcessorOptions(viewFormat(device, [new UniformFormat('matrix_viewProjection', UNIFORMTYPE_FLOAT)]));
+            expect(changed.generateKey(webgl)).to.not.equal(key);
+        });
+
+    });
+
+});

--- a/test/platform/graphics/uniform-buffer-format.test.mjs
+++ b/test/platform/graphics/uniform-buffer-format.test.mjs
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import { UNIFORMTYPE_FLOAT, UNIFORMTYPE_MAT4, UNIFORMTYPE_VEC3, UNIFORMTYPE_VEC4 } from '../../../src/platform/graphics/constants.js';
+import { ScopeSpace } from '../../../src/platform/graphics/scope-space.js';
+import { UniformBufferFormat, UniformFormat } from '../../../src/platform/graphics/uniform-buffer-format.js';
+
+describe('UniformBufferFormat', function () {
+
+    const device = { scope: new ScopeSpace('test') };
+
+    describe('#key', function () {
+
+        it('is the same for formats with the same uniforms', function () {
+            const a = new UniformBufferFormat(device, [new UniformFormat('color', UNIFORMTYPE_VEC4), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            const b = new UniformBufferFormat(device, [new UniformFormat('color', UNIFORMTYPE_VEC4), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            expect(a.key).to.be.a('string').that.is.not.empty;
+            expect(a.key).to.equal(b.key);
+        });
+
+        it('differs when a uniform name, type, array size or order differs', function () {
+            const base = new UniformBufferFormat(device, [new UniformFormat('color', UNIFORMTYPE_VEC4), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            const renamed = new UniformBufferFormat(device, [new UniformFormat('tint', UNIFORMTYPE_VEC4), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            const retyped = new UniformBufferFormat(device, [new UniformFormat('color', UNIFORMTYPE_VEC3), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            const arrayed = new UniformBufferFormat(device, [new UniformFormat('color', UNIFORMTYPE_VEC4, 2), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            const reordered = new UniformBufferFormat(device, [new UniformFormat('depth', UNIFORMTYPE_FLOAT), new UniformFormat('color', UNIFORMTYPE_VEC4)]);
+
+            expect(renamed.key).to.not.equal(base.key);
+            expect(retyped.key).to.not.equal(base.key);
+            expect(arrayed.key).to.not.equal(base.key);
+            expect(reordered.key).to.not.equal(base.key);
+        });
+
+        it('is empty for a format without uniforms', function () {
+            const empty = new UniformBufferFormat(device, []);
+            expect(empty.key).to.equal('');
+            expect(empty.byteSize).to.equal(0);
+        });
+
+        it('does not affect the layout', function () {
+            const format = new UniformBufferFormat(device, [new UniformFormat('matrix', UNIFORMTYPE_MAT4), new UniformFormat('depth', UNIFORMTYPE_FLOAT)]);
+            expect(format.byteSize).to.equal(80);
+            expect(format.get('depth').offset).to.equal(16);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Reserves bind group 1 for the upcoming per-material uniform buffer and makes WebGPU pipeline layouts reject gaps, as the first step of moving StandardMaterial uniforms into a material-owned uniform buffer.

**Changes:**
- Bind group indices are now view 0, material 1, mesh textures 2, mesh uniform buffer 3: `BINDGROUP_MATERIAL` is added, `BINDGROUP_MESH` / `BINDGROUP_MESH_UB` are renumbered, and `bindGroupNames` gains `material`. The WebGL2 uniform block binding points and the WGSL struct names follow the names array, so nothing else needed renaming.
- Every pass binds the device's empty bind group at the material index until materials own a uniform buffer: once per pass in the renderer next to the view group, and in the quad renderer and the WebGPU clear renderer. The clear shader takes its group index from the constant instead of a literal `@group(2)`.
- WebGPU pipeline layouts are built by index and assert on a missing format instead of silently compacting a sparse array, which used to shift every following group to a wrong slot. The render pipeline hash gains a slot for the fourth group and its format-count assert follows the names array.
- `UniformBufferFormat` and `BindGroupFormat` compute a layout key in their constructors, with each `Bind*Format` describing its own resource. `ShaderProcessorOptions.generateKey` concatenates those keys with their bind group index instead of `JSON.stringify` of the whole format objects, which included the scope.
- Unit tests for the index layout and the format keys.

**API Changes:**
- New `BINDGROUP_MATERIAL` constant with value 1. `BINDGROUP_MESH` is now 2 and `BINDGROUP_MESH_UB` is now 3. Hand-written WGSL that hard-codes the mesh group indices instead of using the constants has to move to `@group(2)` / `@group(3)`. Compute shaders are unaffected, as they use their own reflected group indices.

**Performance:**
- Shader lookups no longer stringify the uniform and bind group formats on every `getProgram` call.
- WebGPU issues one extra empty bind group set per render pass, not per draw.
