### PR TITLE
perf: Flat per-splat gsplat varyings and fix ComputeRadixSort reallocation on growth

### DIFF
--- a/src/scene/graphics/radix-sort/compute-radix-sort-base.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-base.js
@@ -43,15 +43,22 @@ class ComputeRadixSortBase {
     }
 
     /**
-     * Minimum element capacity for internal buffers. Set by the caller as a high-water mark to
-     * avoid reallocation churn when the workload shrinks; can be lowered to request shrinkage at
-     * the next sort call. Concrete backends size allocations using max(element count for the sort,
-     * `capacity`); reallocation is deferred until the next sort when that effective size changes.
-     * Updated by implementations after allocation.
+     * Backing store for {@link capacity}.
      *
      * @type {number}
+     * @protected
      */
-    capacity = 0;
+    _capacity = 0;
+
+    /**
+     * Element count the ping-pong key/value buffers were last allocated for (0 when unallocated).
+     * The buffers hold exactly this many `u32` entries, so a sort over more elements must
+     * reallocate even when its partition count is unchanged.
+     *
+     * @type {number}
+     * @protected
+     */
+    _allocatedElementCount = 0;
 
     /**
      * Current element count for the last or in-progress sort.
@@ -137,6 +144,29 @@ class ComputeRadixSortBase {
      * @protected
      */
     _indirectInfo = new Uint32Array(4);
+
+    /**
+     * Minimum element capacity for internal buffers. Set by the caller as a high-water mark to
+     * avoid reallocation churn when the workload shrinks; can be lowered to request shrinkage at
+     * the next sort call. Concrete backends size allocations using max(element count for the sort,
+     * `capacity`) and update it after allocation.
+     *
+     * Raising it above the current allocation releases the undersized element buffers, so
+     * {@link sortedIndices} and {@link sortedKeys} return `null` until the next sort allocates at
+     * the new size. Lowering it keeps the existing, larger buffers until the next sort.
+     *
+     * @type {number}
+     */
+    set capacity(value) {
+        this._capacity = value;
+        if (value > this._allocatedElementCount) {
+            this._destroyPingPongBuffers();
+        }
+    }
+
+    get capacity() {
+        return this._capacity;
+    }
 
     /**
      * Returns the sorted indices (or values, when `initialValues` was passed) buffer of the last
@@ -264,6 +294,7 @@ class ComputeRadixSortBase {
         this._values1 = new StorageBuffer(device, elementSize, usage);
         DebugHelper.setName(this._values0, 'ComputeRadixSort.values0');
         DebugHelper.setName(this._values1, 'ComputeRadixSort.values1');
+        this._allocatedElementCount = effectiveCount;
     }
 
     /**
@@ -282,6 +313,7 @@ class ComputeRadixSortBase {
         this._keys1 = null;
         this._values0 = null;
         this._values1 = null;
+        this._allocatedElementCount = 0;
     }
 
     /**

--- a/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-multipass.js
@@ -78,8 +78,7 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
     _workgroupCount = 0;
 
     /**
-     * Allocated workgroup capacity (buffer sizing). Buffers are only
-     * reallocated when this value changes. Always `>= _workgroupCount`.
+     * Allocated workgroup capacity (sizes `_blockSums`). Always `>= _workgroupCount`.
      */
     _allocatedWorkgroupCount = 0;
 
@@ -302,7 +301,13 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
         const allocWorkgroupCount = Math.ceil(effectiveCount / ELEMENTS_PER_WORKGROUP);
         const currentWorkgroupCount = Math.max(1, Math.ceil(elementCount / ELEMENTS_PER_WORKGROUP));
 
-        const buffersNeedRealloc = forceRealloc || allocWorkgroupCount !== this._allocatedWorkgroupCount || !this._keys0;
+        // The ping-pong buffers hold exactly _allocatedElementCount entries, so any growth of the
+        // effective count must reallocate, even within the same workgroup partition. Shrinking only
+        // reallocates when a lowered capacity drops the workgroup count, which releases memory
+        // without churning on frame-to-frame count changes.
+        const buffersNeedRealloc = forceRealloc || !this._keys0 ||
+            effectiveCount > this._allocatedElementCount ||
+            allocWorkgroupCount < this._allocatedWorkgroupCount;
 
         // Recreate passes when numBits, initial-values mode, or key-write mode changes
         const passesNeedRecreate = numBits !== this._numBits ||
@@ -315,7 +320,7 @@ class ComputeRadixSortMultipass extends ComputeRadixSortBase {
 
             // Store the new capacity
             this._allocatedWorkgroupCount = allocWorkgroupCount;
-            this.capacity = effectiveCount;
+            this._capacity = effectiveCount;
 
             const blockSumSize = BUCKET_COUNT * allocWorkgroupCount * 4;
 

--- a/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort-onesweep.js
@@ -77,8 +77,7 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
     _threadBlocks = 0;
 
     /**
-     * Allocated thread-block capacity (buffer sizing). Buffers are only
-     * reallocated when this value changes. Always `>= _threadBlocks`.
+     * Allocated thread-block capacity (sizes `_passHist`). Always `>= _threadBlocks`.
      *
      * @type {number}
      */
@@ -380,13 +379,17 @@ class ComputeRadixSortOneSweep extends ComputeRadixSortBase {
         const allocThreadBlocks = Math.max(1, Math.ceil(effectiveCount / PART_SIZE));
         const currentThreadBlocks = Math.max(1, Math.ceil(elementCount / PART_SIZE));
 
-        const needRealloc = forceRealloc || allocThreadBlocks !== this._allocatedThreadBlocks || !this._keys0;
+        // See ComputeRadixSortMultipass._allocateBuffers: grow on any effective-count increase,
+        // shrink only when a lowered capacity drops the thread-block count.
+        const needRealloc = forceRealloc || !this._keys0 ||
+            effectiveCount > this._allocatedElementCount ||
+            allocThreadBlocks < this._allocatedThreadBlocks;
 
         if (needRealloc) {
             this._destroyBuffers();
 
             this._allocatedThreadBlocks = allocThreadBlocks;
-            this.capacity = effectiveCount;
+            this._capacity = effectiveCount;
 
             const device = this.device;
 

--- a/src/scene/graphics/radix-sort/compute-radix-sort.js
+++ b/src/scene/graphics/radix-sort/compute-radix-sort.js
@@ -154,7 +154,10 @@ class ComputeRadixSort {
     /**
      * High-water mark for internal buffer allocation. Setting this raises
      * the floor for the next sort's allocation; lowering it requests
-     * shrinkage at the next sort call.
+     * shrinkage at the next sort call. Raising it above the current
+     * allocation releases the undersized result buffers, so
+     * {@link sortedIndices} and {@link sortedKeys} return `null` until the
+     * next sort has run at the new size.
      *
      * @type {number}
      */

--- a/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/frag/gsplat.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 #ifndef DITHER_NONE
     #include "bayerPS"
     #include "opacityDitherPS"
-    varying float id;
+    flat varying float id;
 #endif
 
 #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
@@ -11,13 +11,13 @@ export default /* glsl */`
 #endif
 
 #ifdef PREPASS_PASS
-    varying float vLinearDepth;
+    flat varying float vLinearDepth;
     #include "floatAsUintPS"
 #endif
 
 // the prepass declares this varying above, and the two passes are never generated as one
 #if defined(SCENE_TEXTURE_DEPTH) && !defined(PREPASS_PASS)
-    varying float vLinearDepth;
+    flat varying float vLinearDepth;
 #endif
 
 #include "sceneTexturesPS"
@@ -27,7 +27,7 @@ export default /* glsl */`
 #endif
 
 varying mediump vec2 gaussianUV;
-varying mediump vec4 gaussianColor;
+flat varying mediump vec4 gaussianColor;
 
 #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
     flat varying uint vPickId;

--- a/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/glsl/chunks/gsplat/vert/gsplat.js
@@ -5,16 +5,16 @@ export default /* glsl */`
 #include "gsplatCommonVS"
 
 varying mediump vec2 gaussianUV;
-varying mediump vec4 gaussianColor;
+flat varying mediump vec4 gaussianColor;
 
 #ifndef DITHER_NONE
-    varying float id;
+    flat varying float id;
 #endif
 
 mediump vec4 discardVec = vec4(0.0, 0.0, 2.0, 1.0);
 
 #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
-    varying float vLinearDepth;
+    flat varying float vLinearDepth;
 #endif
 
 #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/frag/gsplat.js
@@ -3,7 +3,7 @@ export default /* wgsl */`
 #ifndef DITHER_NONE
     #include "bayerPS"
     #include "opacityDitherPS"
-    varying id: f32;
+    varying @interpolate(flat) id: f32;
 #endif
 
 #if defined(SHADOW_PASS) || defined(PICK_PASS) || defined(PREPASS_PASS)
@@ -11,13 +11,13 @@ export default /* wgsl */`
 #endif
 
 #ifdef PREPASS_PASS
-    varying vLinearDepth: f32;
+    varying @interpolate(flat) vLinearDepth: f32;
     #include "floatAsUintPS"
 #endif
 
 // the prepass declares this varying above, and the two passes are never generated as one
 #if defined(SCENE_TEXTURE_DEPTH) && !defined(PREPASS_PASS)
-    varying vLinearDepth: f32;
+    varying @interpolate(flat) vLinearDepth: f32;
 #endif
 
 #include "sceneTexturesPS"
@@ -34,7 +34,7 @@ fn normExp(x: half) -> half {
 }
 
 varying gaussianUV: half2;
-varying gaussianColor: half4;
+varying @interpolate(flat) gaussianColor: half4;
 
 #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)
     varying @interpolate(flat) vPickId: u32;

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplat.js
@@ -5,16 +5,16 @@ export default /* wgsl */`
 #include "gsplatCommonVS"
 
 varying gaussianUV: half2;
-varying gaussianColor: half4;
+varying @interpolate(flat) gaussianColor: half4;
 
 #ifndef DITHER_NONE
-    varying id: f32;
+    varying @interpolate(flat) id: f32;
 #endif
 
 const discardVec: vec4f = vec4f(0.0, 0.0, 2.0, 1.0);
 
 #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
-    varying vLinearDepth: f32;
+    varying @interpolate(flat) vLinearDepth: f32;
 #endif
 
 #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)

--- a/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
+++ b/src/scene/shader-lib/wgsl/chunks/gsplat/vert/gsplatHybrid.js
@@ -67,14 +67,14 @@ var<storage, read> projCache: array<u32>;
 var<storage, read> numSplatsStorage: array<u32>;
 
 varying gaussianUV: half2;
-varying gaussianColor: half4;
+varying @interpolate(flat) gaussianColor: half4;
 
 #ifndef DITHER_NONE
-    varying id: f32;
+    varying @interpolate(flat) id: f32;
 #endif
 
 #if defined(PREPASS_PASS) || defined(SCENE_TEXTURE_DEPTH)
-    varying vLinearDepth: f32;
+    varying @interpolate(flat) vLinearDepth: f32;
 #endif
 
 #if defined(GSPLAT_UNIFIED_ID) && defined(PICK_PASS)

--- a/test/scene/graphics/radix-sort/compute-radix-sort.test.mjs
+++ b/test/scene/graphics/radix-sort/compute-radix-sort.test.mjs
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+
+import { NullGraphicsDevice } from '../../../../src/platform/graphics/null/null-graphics-device.js';
+import { StorageBuffer } from '../../../../src/platform/graphics/storage-buffer.js';
+import { RADIX_SORT_ONESWEEP, RADIX_SORT_PORTABLE } from '../../../../src/scene/constants.js';
+import { ComputeRadixSort } from '../../../../src/scene/graphics/radix-sort/compute-radix-sort.js';
+
+// The Null device has no compute or storage buffer backend; stub just enough for the sorters to
+// build their pipelines and allocate buffers. Dispatches are no-ops, so only allocation behaviour
+// is observable here.
+const createDevice = () => {
+    const device = new NullGraphicsDevice({ width: 16, height: 16 });
+    device.supportsCompute = true;
+    device.supportsSubgroups = true;
+    device.minSubgroupSize = 32;
+    device.maxSubgroupSize = 32;
+    device.gpuAdapter = { info: { vendor: 'nvidia' } };
+    device.limits = { maxComputeWorkgroupsPerDimension: 65535 };
+    device.createBufferImpl = () => ({ allocate() {}, destroy() {}, clear() {}, loseContext() {}, restoreContext() {} });
+    device.createComputeImpl = () => ({ destroy() {} });
+    return device;
+};
+
+const backends = [
+    { name: 'portable', kind: RADIX_SORT_PORTABLE, partition: 2048 },
+    { name: 'OneSweep', kind: RADIX_SORT_ONESWEEP, partition: 3840 }
+];
+
+describe('ComputeRadixSort', function () {
+
+    backends.forEach(({ name, kind, partition }) => {
+
+        describe(`#sort (${name}) buffer allocation`, function () {
+
+            /** @type {NullGraphicsDevice} */
+            let device;
+
+            /** @type {ComputeRadixSort} */
+            let sorter;
+
+            const sort = (count) => {
+                const keys = new StorageBuffer(device, count * 4);
+                sorter.sort(keys, count, 16);
+                keys.destroy();
+            };
+
+            beforeEach(function () {
+                device = createDevice();
+                sorter = new ComputeRadixSort(device, { kind });
+            });
+
+            afterEach(function () {
+                sorter.destroy();
+                device.destroy();
+            });
+
+            it('sizes the result buffers to the element count', function () {
+                const count = partition + 256;
+                sort(count);
+                expect(sorter.sortedIndices.byteSize).to.equal(count * 4);
+                expect(sorter.sortedKeys.byteSize).to.equal(count * 4);
+                expect(sorter.capacity).to.equal(count);
+            });
+
+            it('grows the buffers when the count grows within the same partition', function () {
+                const count = partition + 256;
+                sort(count);
+                sort(count + 256);
+                expect(sorter.sortedIndices.byteSize).to.equal((count + 256) * 4);
+                expect(sorter.sortedKeys.byteSize).to.equal((count + 256) * 4);
+                expect(sorter.capacity).to.equal(count + 256);
+            });
+
+            it('keeps the buffers when the count shrinks', function () {
+                const count = partition + 256;
+                sort(count);
+                const indices = sorter.sortedIndices;
+                sort(count - 1);
+                expect(sorter.sortedIndices).to.equal(indices);
+                expect(sorter.capacity).to.equal(count);
+            });
+
+            it('releases the result buffers when capacity is raised above the allocation', function () {
+                const count = partition + 256;
+                sort(count);
+                sorter.capacity = count + 1;
+                expect(sorter.sortedIndices).to.equal(null);
+                expect(sorter.sortedKeys).to.equal(null);
+                sort(count);
+                expect(sorter.sortedIndices.byteSize).to.equal((count + 1) * 4);
+            });
+
+            it('keeps the result buffers when capacity is lowered, and shrinks at the next sort', function () {
+                const count = partition * 2 + 256;
+                sort(count);
+                const indices = sorter.sortedIndices;
+                sorter.capacity = partition;
+                expect(sorter.sortedIndices).to.equal(indices);
+                sort(partition);
+                expect(sorter.sortedIndices.byteSize).to.equal(partition * 4);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Overview

Two follow-ups from profiling the hybrid gsplat pipeline (compute projector → GPU radix sort → instanced quad draw) on WebGPU. The first removes per-fragment interpolation work for varyings that are constant across each splat quad. The second fixes a buffer sizing bug in `ComputeRadixSort` that writes past the end of its key/value buffers when the element count grows without crossing a partition boundary.

## Changes

- `gaussianColor`, `id` and `vLinearDepth` are now flat varyings in `gsplatVS`, `gsplatHybridVS` and `gsplatPS` (WGSL) and in `gsplatVS` / `gsplatPS` (GLSL). They are computed once per splat and written identically to all four quad vertices, so the output is bit-identical; only `gaussianUV` still interpolates.
- `ComputeRadixSort` reallocates its ping-pong key/value buffers whenever the effective element count grows, not only when the workgroup / thread-block count changes. Previously a sort growing from e.g. 2304 to 2560 elements (both within one 2048-element partition on the portable backend) kept 2304-element buffers and wrote the tail out of bounds, producing a wrong order for the last elements under WebGPU robustness clamping. The hybrid renderer hits this whenever `totalActiveSplats` grows by less than a partition.
- Shrinking still only reallocates when a lowered `capacity` drops the partition count, so frame-to-frame count changes below the high-water mark never churn.
- `capacity` is now an accessor. Raising it above the current allocation releases the undersized buffers so `sortedIndices` / `sortedKeys` return `null` until the next sort allocates at the new size. Lowering it keeps the existing larger buffers until the next sort, as before.
- New test `test/scene/graphics/radix-sort/compute-radix-sort.test.mjs` drives the public `sort()` on both backends through the facade on a stubbed `NullGraphicsDevice`: growth within a partition, shrink without reallocation, raise capacity → null result, lower capacity → shrink at next sort.

## Technical details

- `ComputeRadixSortBase` tracks `_allocatedElementCount`, recorded in `_allocatePingPongElementBuffers` and reset in `_destroyPingPongBuffers`. Both backends' `_allocateBuffers` reallocate when `effectiveCount > _allocatedElementCount`, when the buffers do not exist, when `forceRealloc` is set, or when the allocated partition count drops. The partition count still sizes `_blockSums` / `_passHist` but no longer triggers reallocation on its own.
- The backends write `_capacity` directly after allocation so the setter's invalidation does not re-enter during allocation.

## Behaviour change (internal API)

`ComputeRadixSort` is `@ignore` but consumers that reuse the sorter's result buffer outside `sort()` (SuperSplat's stochastic draw order does this) rely on the new `capacity` contract:

```js
sorter.sort(keys, n, 16);
sorter.capacity = n + 1;
sorter.sortedIndices; // before: stale buffer sized for n   after: null until the next sort